### PR TITLE
Add a data module

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,139 @@
+use super::measurement::*;
+
+// Constants
+const OCTET_BIT_FACTOR: f64 = 0.125;
+
+// Constants, legacy
+const OCTET_KILOOCTET_FACTOR: f64 = 1000.;
+const OCTET_MEGAOCTET_FACTOR: f64 = 1000000.;
+const OCTET_GIGAOCTET_FACTOR: f64 = 1000000000.;
+const OCTET_TERAOCTET_FACTOR: f64 = 1000000000000.;
+
+// Constants, SI
+const OCTET_KIBIOCTET_FACTOR: f64 = 1024.;
+const OCTET_MEBIOCTET_FACTOR: f64 = 1048576.;
+const OCTET_GIBIOCTET_FACTOR: f64 = 1073741824.;
+const OCTET_TEBIOCTET_FACTOR: f64 = 1099511627776.;
+
+/// The `Data` struct can be used to deal with computer information in a common way.
+/// Common legacy and SI units are supported.
+///
+/// # Example
+///
+/// ```
+/// use measurements::Data;
+///
+/// let file_size = Data::from_mebioctets(2.5);
+/// let octets = file_size.as_octets();
+/// println!("There are {} octets in that file.", octets);
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Data {
+    octets: f64,
+}
+
+impl Data {
+    // Inputs
+    pub fn from_octets(octets: f64) -> Self {
+        Data { octets: octets }
+    }
+
+    pub fn from_bits(bits: f64) -> Self {
+        Self::from_octets(bits * OCTET_BIT_FACTOR)
+    }
+
+    // Inputs, legacy
+    pub fn from_kilooctets(kilooctets: f64) -> Self {
+        Self::from_octets(kilooctets * OCTET_KILOOCTET_FACTOR)
+    }
+
+    pub fn from_megaoctets(megaoctets: f64) -> Self {
+        Self::from_octets(megaoctets * OCTET_MEGAOCTET_FACTOR)
+    }
+
+    pub fn from_gigaoctets(gigaoctets: f64) -> Self {
+        Self::from_octets(gigaoctets * OCTET_GIGAOCTET_FACTOR)
+    }
+
+    pub fn from_teraoctets(teraoctets: f64) -> Self {
+        Self::from_octets(teraoctets * OCTET_TERAOCTET_FACTOR)
+    }
+
+    // Inputs, SI
+    pub fn from_kibioctets(kibioctets: f64) -> Self {
+        Self::from_octets(kibioctets * OCTET_KIBIOCTET_FACTOR)
+    }
+
+    pub fn from_mebioctets(mebioctets: f64) -> Self {
+        Self::from_octets(mebioctets * OCTET_MEBIOCTET_FACTOR)
+    }
+
+    pub fn from_gibioctets(gibioctets: f64) -> Self {
+        Self::from_octets(gibioctets * OCTET_GIBIOCTET_FACTOR)
+    }
+
+    pub fn from_tebioctets(tebioctets: f64) -> Self {
+        Self::from_octets(tebioctets * OCTET_TEBIOCTET_FACTOR)
+    }
+
+    // Outputs
+    pub fn as_octets(&self) -> f64 {
+        self.octets
+    }
+
+    pub fn as_bits(&self) -> f64 {
+        self.octets / OCTET_BIT_FACTOR
+    }
+
+    // Outputs, legacy
+    pub fn as_kilooctets(&self) -> f64 {
+        self.octets / OCTET_KILOOCTET_FACTOR
+    }
+
+    pub fn as_megaoctets(&self) -> f64 {
+        self.octets / OCTET_MEGAOCTET_FACTOR
+    }
+
+    pub fn as_gigaoctets(&self) -> f64 {
+        self.octets / OCTET_GIGAOCTET_FACTOR
+    }
+
+    pub fn as_teraoctets(&self) -> f64 {
+        self.octets / OCTET_TERAOCTET_FACTOR
+    }
+
+    // Outputs, SI
+    pub fn as_kibioctets(&self) -> f64 {
+        self.octets / OCTET_KIBIOCTET_FACTOR
+    }
+
+    pub fn as_mebioctets(&self) -> f64 {
+        self.octets / OCTET_MEBIOCTET_FACTOR
+    }
+
+    pub fn as_gibioctets(&self) -> f64 {
+        self.octets / OCTET_GIBIOCTET_FACTOR
+    }
+
+    pub fn as_tebioctets(&self) -> f64 {
+        self.octets / OCTET_TEBIOCTET_FACTOR
+    }
+}
+
+impl Measurement for Data {
+    fn get_base_units(&self) -> f64 {
+        self.octets
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_octets(units)
+    }
+}
+
+implement_measurement! { Data }
+
+impl ::std::fmt::Display for Data {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{:.1} o", self.as_octets())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,10 @@ pub use volume::Volume;
 mod pressure;
 pub use pressure::Pressure;
 
+#[allow(dead_code)]
+mod data;
+pub use data::Data;
+
 // Include when running tests, but don't export them
 #[cfg(test)]
 #[allow(dead_code)]

--- a/src/tests/data_tests.rs
+++ b/src/tests/data_tests.rs
@@ -1,0 +1,173 @@
+use data::*;
+use super::assert_almost_eq;
+
+// Metric
+#[test]
+fn bits() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_bits();
+
+    let i2 = Data::from_bits(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 800.0);
+    assert_almost_eq(r2, 12.5);
+}
+
+#[test]
+fn kilooctet() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_kilooctets();
+
+    let i2 = Data::from_kilooctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 0.1);
+    assert_almost_eq(r2, 1e5);
+}
+
+#[test]
+fn megaoctet() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_megaoctets();
+
+    let i2 = Data::from_megaoctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 0.0001);
+    assert_almost_eq(r2, 1e8);
+}
+
+#[test]
+fn gigaoctet() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_gigaoctets();
+
+    let i2 = Data::from_gigaoctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 1e-7);
+    assert_almost_eq(r2, 1e11);
+}
+
+#[test]
+fn teraoctet() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_teraoctets();
+
+    let i2 = Data::from_teraoctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 1e-10);
+    assert_almost_eq(r2, 1e14);
+}
+
+// Imperial
+#[test]
+fn kibioctet() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_kibioctets();
+
+    let i2 = Data::from_kibioctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 0.09765625);
+    assert_almost_eq(r2, 102400.0);
+}
+
+#[test]
+fn mebioctet() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_mebioctets();
+
+    let i2 = Data::from_mebioctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 9.536743e-5);
+    assert_almost_eq(r2, 104857600.0);
+}
+
+#[test]
+fn gibioctets() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_gibioctets();
+
+    let i2 = Data::from_gibioctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 9.313226e-8);
+    assert_almost_eq(r2, 107374182400.0);
+}
+
+#[test]
+fn tebioctets() {
+    let i1 = Data::from_octets(100.0);
+    let r1 = i1.as_tebioctets();
+
+    let i2 = Data::from_tebioctets(100.0);
+    let r2 = i2.as_octets();
+
+    assert_almost_eq(r1, 9.094947e-11);
+    assert_almost_eq(r2, 109951162777600.0);
+}
+
+// Traits
+#[test]
+fn add() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(4.0);
+    let c = a + b;
+    assert_almost_eq(c.as_octets(), 6.0);
+}
+
+#[test]
+fn sub() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(4.0);
+    let c = a - b;
+    assert_almost_eq(c.as_octets(), -2.0);
+}
+
+#[test]
+fn mul() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(4.0);
+    let c = a * b;
+    let d = b * 2.0;
+    assert_almost_eq(c.as_octets(), 8.0);
+    assert_almost_eq(d.as_octets(), 8.0);
+}
+
+#[test]
+fn div() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(4.0);
+    let c = a * b;
+    let d = a * 2.0;
+    assert_almost_eq(c.as_octets(), 8.0);
+    assert_almost_eq(d.as_octets(), 4.0);
+}
+
+#[test]
+fn eq() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(2.0);
+    assert_eq!(a == b, true);
+}
+
+#[test]
+fn neq() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(4.0);
+    assert_eq!(a == b, false);
+}
+
+#[test]
+fn cmp() {
+    let a = Data::from_octets(2.0);
+    let b = Data::from_octets(4.0);
+    assert_eq!(a < b, true);
+    assert_eq!(a <= b, true);
+    assert_eq!(a > b, false);
+    assert_eq!(a >= b, false);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod length_tests;
 mod temperature_tests;
 mod weight_tests;
 mod volume_tests;
+mod data_tests;
 
 const DEFAULT_DELTA: f64 = 0.00001;
 


### PR DESCRIPTION
This is a measure for computer information, it goes down to bits but
the internal value is the octet.

We decided against using the byte as the internal value because its
size is architecture-dependent, on DSPs for example a byte could be
16 bits instead of 8 as it is usually understood.  The octet on the
other hand is always defined as eight bits.

This was done as part of the Cambridge Rust meetup.