### PR TITLE
Add Current and Resistance units

### DIFF
--- a/src/current.rs
+++ b/src/current.rs
@@ -1,0 +1,171 @@
+//! Types and constants for handling electrical current.
+
+use super::measurement::*;
+
+/// The `Current` struct can be used to deal with electric potential difference
+/// in a common way.
+///
+/// # Example
+///
+/// ```
+/// use measurements::Current;
+///
+/// let amperes = Current::from_milliamperes(35.0);
+/// let a = amperes.as_amperes();
+/// let u_a = amperes.as_microamperes();
+/// println!("35 mA correspond to {} A or {} µA", a, u_a);
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Current {
+    amperes: f64,
+}
+
+impl Current {
+    /// Create a new Current from a floating point value in amperes
+    pub fn from_amperes(amperes: f64) -> Self {
+        Current { amperes }
+    }
+
+    /// Create a new Current from a floating point value in milliamperes
+    pub fn from_milliamperes(milliamperes: f64) -> Self {
+        Self::from_amperes(milliamperes / 1000.0)
+    }
+
+    /// Create a new Current from a floating point value in microamperes
+    pub fn from_microamperes(microamperes: f64) -> Self {
+        Self::from_amperes(microamperes / 1000.0 / 1000.0)
+    }
+
+    /// Convert this Current into a floating point value in amperes
+    pub fn as_amperes(&self) -> f64 {
+        self.amperes
+    }
+
+    /// Convert this Current into a floating point value in milliamperes
+    pub fn as_milliamperes(&self) -> f64 {
+        self.amperes * 1000.0
+    }
+
+    /// Convert this Current into a floating point value in microamperes
+    pub fn as_microamperes(&self) -> f64 {
+        self.amperes * 1000.0 * 1000.0
+    }
+}
+
+impl Measurement for Current {
+    fn as_base_units(&self) -> f64 {
+        self.amperes
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_amperes(units)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "A"
+    }
+
+    fn get_appropriate_units(&self) -> (&'static str, f64) {
+        // Smallest to Largest
+        let list = [
+            ("fA", 1e-15),
+            ("pA", 1e-12),
+            ("nA", 1e-9),
+            ("\u{00B5}A", 1e-6),
+            ("mA", 1e-3),
+            ("A", 1e0),
+            ("kA", 1e3),
+            ("MA", 1e6),
+            ("GA", 1e9),
+            ("TA", 1e12),
+            ("PA", 1e15),
+            ("EA", 1e18),
+        ];
+        self.pick_appropriate_units(&list)
+    }
+}
+
+implement_measurement! { Current }
+
+#[cfg(test)]
+mod test {
+    use current::*;
+    use test_utils::assert_almost_eq;
+
+    #[test]
+    pub fn as_amperes() {
+        let u = Current::from_milliamperes(1234.0);
+        assert_almost_eq(u.as_amperes(), 1.234);
+    }
+
+    #[test]
+    pub fn as_milliamperes() {
+        let u = Current::from_amperes(1.234);
+        assert_almost_eq(u.as_milliamperes(), 1234.0);
+    }
+
+    #[test]
+    pub fn as_microamperes() {
+        let u = Current::from_amperes(0.001);
+        assert_almost_eq(u.as_microamperes(), 1000.0);
+    }
+
+    // Traits
+    #[test]
+    fn add() {
+        let a = Current::from_amperes(2.0);
+        let b = Current::from_milliamperes(4000.0);
+        let c = a + b;
+        assert_almost_eq(c.as_amperes(), 6.0);
+    }
+
+    #[test]
+    fn sub() {
+        let a = Current::from_amperes(2.0);
+        let b = Current::from_milliamperes(4000.0);
+        let c = a - b;
+        assert_almost_eq(c.as_amperes(), -2.0);
+    }
+
+    #[test]
+    fn mul() {
+        let a = Current::from_milliamperes(2000.0);
+        let b = 4.0 * a;
+        assert_almost_eq(b.as_amperes(), 8.0);
+    }
+
+    #[test]
+    fn div() {
+        let a = Current::from_amperes(2.0);
+        let b = Current::from_milliamperes(4000.0);
+        let c = a / b;
+        let d = a / 2.0;
+        assert_almost_eq(c, 0.5);
+        assert_almost_eq(d.as_amperes(), 1.0);
+    }
+
+    #[test]
+    fn eq() {
+        let a = Current::from_microamperes(1_000_000.0);
+        let b = Current::from_milliamperes(1_000.0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn neq() {
+        let a = Current::from_amperes(2.0);
+        let b = Current::from_milliamperes(2.0);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cmp() {
+        let a = Current::from_amperes(2.0);
+        let b = Current::from_amperes(4.0);
+        assert_eq!(a < b, true);
+        assert_eq!(a <= b, true);
+        assert_eq!(a > b, false);
+        assert_eq!(a >= b, false);
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ pub use power::Power;
 pub mod voltage;
 pub use voltage::Voltage;
 
+pub mod current;
+pub use current::Current;
+
 pub mod force;
 pub use force::Force;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@ impl_maths!(Power, Force, Speed);
 impl_maths!(Speed, time::Duration, Acceleration);
 impl_maths!(Volume, Length, Area);
 impl_maths!(Power, AngularVelocity, Torque);
+impl_maths!(Power, Voltage, Current);
 impl_maths!(Voltage, Resistance, Current);
 
 // Force * Distance is ambiguous. Create an ambiguous struct the user can then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,6 +160,7 @@ impl_maths!(Power, Force, Speed);
 impl_maths!(Speed, time::Duration, Acceleration);
 impl_maths!(Volume, Length, Area);
 impl_maths!(Power, AngularVelocity, Torque);
+impl_maths!(Voltage, Resistance, Current);
 
 // Force * Distance is ambiguous. Create an ambiguous struct the user can then
 // cast into either Torque or Energy.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub use voltage::Voltage;
 pub mod current;
 pub use current::Current;
 
+pub mod resistance;
+pub use resistance::Resistance;
+
 pub mod force;
 pub use force::Force;
 

--- a/src/power.rs
+++ b/src/power.rs
@@ -128,6 +128,8 @@ implement_measurement! { Power }
 #[cfg(test)]
 mod test {
     use power::*;
+    use current::*;
+    use voltage::*;
     use test_utils::assert_almost_eq;
 
     #[test]
@@ -226,6 +228,30 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    fn mul_voltage_current() {
+        let u = Voltage::from_volts(230.0);
+        let i = Current::from_amperes(10.0);
+        let p = u * i;
+        assert_almost_eq(p.as_kilowatts(), 2.3);
+    }
+
+    #[test]
+    fn div_voltage() {
+        let u = Voltage::from_volts(230.0);
+        let p = Power::from_kilowatts(2.3);
+        let i = p / u;
+        assert_eq!(i.as_amperes(), 10.0);
+    }
+
+    #[test]
+    fn div_current() {
+        let i = Current::from_amperes(10.0);
+        let p = Power::from_kilowatts(2.3);
+        let u = p / i;
+        assert_eq!(u.as_volts(), 230.0);
     }
 
 }

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -1,0 +1,170 @@
+//! Types and constants for handling electrical resistance.
+
+use super::measurement::*;
+
+/// The `Resistance` struct can be used to deal with electrical resistance in a
+/// common way.
+///
+/// # Example
+///
+/// ```
+/// use measurements::Resistance;
+///
+/// let r = Resistance::from_kiloohms(4.7);
+/// let o = r.as_ohms();
+/// let mo = r.as_megaohms();
+/// println!("A 4.7 kΩ resistor has {} Ω or {} MΩ", o, mo);
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Resistance {
+    ohms: f64,
+}
+
+impl Resistance {
+    /// Create a new Resistance from a floating point value in ohms
+    pub fn from_ohms(ohms: f64) -> Self {
+        Resistance { ohms }
+    }
+
+    /// Create a new Resistance from a floating point value in kiloohms
+    pub fn from_kiloohms(kiloohms: f64) -> Self {
+        Self::from_ohms(kiloohms * 1000.0)
+    }
+
+    /// Create a new Resistance from a floating point value in milliohms
+    pub fn from_megaohms(megaohms: f64) -> Self {
+        Self::from_ohms(megaohms * 1000.0 * 1000.0)
+    }
+
+    /// Convert this Resistance into a floating point value in ohms
+    pub fn as_ohms(&self) -> f64 {
+        self.ohms
+    }
+
+    /// Convert this Resistance into a floating point value in kiloohms
+    pub fn as_kiloohms(&self) -> f64 {
+        self.ohms / 1000.0
+    }
+
+    /// Convert this Resistance into a floating point value in milliohms
+    pub fn as_megaohms(&self) -> f64 {
+        self.ohms / 1000.0 / 1000.0
+    }
+}
+
+impl Measurement for Resistance {
+    fn as_base_units(&self) -> f64 {
+        self.ohms
+    }
+
+    fn from_base_units(units: f64) -> Self {
+        Self::from_ohms(units)
+    }
+
+    fn get_base_units_name(&self) -> &'static str {
+        "\u{2126}"
+    }
+
+    fn get_appropriate_units(&self) -> (&'static str, f64) {
+        // Smallest to Largest
+        let list = [
+            ("f\u{2126}", 1e-15),
+            ("p\u{2126}", 1e-12),
+            ("n\u{2126}", 1e-9),
+            ("\u{00B5}\u{2126}", 1e-6),
+            ("m\u{2126}", 1e-3),
+            ("\u{2126}", 1e0),
+            ("k\u{2126}", 1e3),
+            ("M\u{2126}", 1e6),
+            ("G\u{2126}", 1e9),
+            ("T\u{2126}", 1e12),
+            ("P\u{2126}", 1e15),
+            ("E\u{2126}", 1e18),
+        ];
+        self.pick_appropriate_units(&list)
+    }
+}
+
+implement_measurement! { Resistance }
+
+#[cfg(test)]
+mod test {
+    use resistance::*;
+    use test_utils::assert_almost_eq;
+
+    #[test]
+    pub fn as_ohms() {
+        let u = Resistance::from_kiloohms(1.234);
+        assert_almost_eq(u.as_ohms(), 1234.0);
+    }
+
+    #[test]
+    pub fn as_kiloohms() {
+        let u = Resistance::from_ohms(10_000.0);
+        assert_almost_eq(u.as_kiloohms(), 10.0);
+    }
+
+    #[test]
+    pub fn as_megaohms() {
+        let u = Resistance::from_ohms(1_234_567.0);
+        assert_almost_eq(u.as_megaohms(), 1.234567);
+    }
+
+    // Traits
+    #[test]
+    fn add() {
+        let a = Resistance::from_ohms(2000.0);
+        let b = Resistance::from_kiloohms(4.0);
+        let c = a + b;
+        assert_almost_eq(c.as_kiloohms(), 6.0);
+    }
+
+    #[test]
+    fn sub() {
+        let a = Resistance::from_megaohms(2.0);
+        let b = Resistance::from_kiloohms(4000.0);
+        let c = a - b;
+        assert_almost_eq(c.as_ohms(), -2_000_000.0);
+    }
+
+    #[test]
+    fn mul() {
+        let a = Resistance::from_ohms(2000.0);
+        let b = 4.0 * a;
+        assert_almost_eq(b.as_kiloohms(), 8.0);
+    }
+
+    #[test]
+    fn div() {
+        let a = Resistance::from_kiloohms(2.0);
+        let b = Resistance::from_ohms(4000.0);
+        let c = a / b;
+        let d = a / 2.0;
+        assert_almost_eq(c, 0.5);
+        assert_almost_eq(d.as_ohms(), 1000.0);
+    }
+
+    #[test]
+    fn eq() {
+        let a = Resistance::from_ohms(1_000_000.0);
+        let b = Resistance::from_megaohms(1.0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn neq() {
+        let a = Resistance::from_ohms(2.0);
+        let b = Resistance::from_megaohms(2.0);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn cmp() {
+        let a = Resistance::from_ohms(2.0);
+        let b = Resistance::from_ohms(4.0);
+        assert_eq!(a < b, true);
+        assert_eq!(a <= b, true);
+        assert_eq!(a > b, false);
+        assert_eq!(a >= b, false);
+    }
+}

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -90,6 +90,8 @@ implement_measurement! { Voltage }
 #[cfg(test)]
 mod test {
     use voltage::*;
+    use resistance::*;
+    use current::*;
     use test_utils::assert_almost_eq;
 
     #[test]
@@ -166,6 +168,30 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    fn mul_resistance_current() {
+        let r = Resistance::from_ohms(470.0);
+        let i = Current::from_amperes(2.0);
+        let u = r * i;
+        assert_eq!(u.as_volts(), 940.0);
+    }
+
+    #[test]
+    fn div_resistance() {
+        let r = Resistance::from_ohms(470.0);
+        let u = Voltage::from_kilovolts(4.7);
+        let i = u / r;
+        assert_eq!(i.as_amperes(), 10.0);
+    }
+
+    #[test]
+    fn div_current() {
+        let i = Current::from_amperes(10.0);
+        let u = Voltage::from_kilovolts(4.7);
+        let r = u / i;
+        assert_eq!(r.as_ohms(), 470.0);
     }
 
 }


### PR DESCRIPTION
Add the remaining units for Ohm's law.

Also implement the `P = U * I` relation. This only applies to DC power though, not to AC where the time is relevant. Do you think it's still correct to keep the conversions?

Fixes #9.