### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["James O'Cull <jocull@delmarsd.com>",
           "Jonathan Pallant <github@thejpster.org.uk>",
           "Hannah McLaughlin <h@mcla.ug>",
           "Danilo Bargen <mail@dbrgn.ch>",
+          "Tim Alberdingk Thijm <tthijm@princeton.edu>",
           ]
 documentation = "https://docs.rs/crate/measurements"
 repository = "https://github.com/thejpster/rust-measurements"
@@ -15,3 +16,6 @@ readme = "README.md"
 
 [features]
 no_std = []
+
+[dependencies]
+serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -22,6 +22,7 @@ use super::length;
 ///     println!("You accelerated over {} at an average of {}", track, accel);
 ///}
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Acceleration {
     meters_per_second_per_second: f64,

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -14,6 +14,7 @@ use super::measurement::*;
 /// let slice = whole_cake / pieces;
 /// println!("Each slice will be {} degrees", slice.as_degrees());
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Angle {
     radians: f64,

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -14,6 +14,7 @@ use ::PI;
 /// let engine_speed = AngularVelocity::from_rpm(9000.0);
 /// let sparks_per_second = (engine_speed.as_hertz() / 2.0) * cylinders;
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct AngularVelocity {
     radians_per_second: f64,

--- a/src/area.rs
+++ b/src/area.rs
@@ -18,6 +18,7 @@ const SQUARE_METER_ACRE_FACTOR: f64 = 1.0 / 4046.86;
 /// let acres = football_field.as_acres();
 /// println!("There are {} acres in a football field.", acres);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Area {
     square_meters: f64,

--- a/src/current.rs
+++ b/src/current.rs
@@ -15,6 +15,7 @@ use super::measurement::*;
 /// let u_a = amperes.as_microamperes();
 /// println!("35 mA correspond to {} A or {} µA", a, u_a);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Current {
     amperes: f64,

--- a/src/data.rs
+++ b/src/data.rs
@@ -29,6 +29,7 @@ const OCTET_TEBIOCTET_FACTOR: f64 = 1024.0 * 1024.0 * 1024.0 * 1024.0;
 /// let octets = file_size.as_octets();
 /// println!("There are {} octets in that file.", octets);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Data {
     octets: f64,

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -13,6 +13,7 @@ use super::measurement::*;
 /// let energy = Energy::from_kcalories(2500.0);
 /// println!("Some say a health adult male should consume {} per day", energy);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Energy {
     joules: f64,

--- a/src/force.rs
+++ b/src/force.rs
@@ -28,6 +28,7 @@ pub const DYNES_PER_NEWTON: f64 = 1e5;
 ///     "One metric ton exerts a force of {} due to gravity",
 ///     force);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Force {
     newtons: f64,

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -29,6 +29,7 @@ pub const HERTZ_TERAHERTZ_FACTOR: f64 = 1e-12;
 /// let radio_station = Frequency::from_hertz(101.5e6);
 /// println!("Tune to {}.", radio_station);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Frequency {
     hertz: f64,

--- a/src/length.rs
+++ b/src/length.rs
@@ -44,6 +44,7 @@ pub const METER_MILE_FACTOR: f64 = 1000.0 / (25.4 * 12.0 * 3.0 * 1760.0);
 /// let meters = football_field.as_meters();
 /// println!("There are {} meters in a football field.", meters);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Length {
     meters: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@ use core::time as time;
 #[cfg(not(feature = "no_std"))]
 use std::time as time;
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 use std::f64::consts::PI as PI;
 
 #[macro_use]

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -53,6 +53,7 @@ pub const KILOGRAM_LONG_TONS_FACTOR: f64 = KILOGRAM_POUNDS_FACTOR / 2240.0;
 ///     "One metric ton is {} U.S. tons - that's {} pounds!",
 ///     united_states_tons, united_states_pounds);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Mass {
     kilograms: f64,

--- a/src/power.rs
+++ b/src/power.rs
@@ -27,6 +27,7 @@ pub const WATT_PS_FACTOR: f64 = 1.0 / 735.499;
 /// let k_w = power.as_kilowatts();
 /// println!("A 100.0 hp car produces {} kW", k_w);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Power {
     watts: f64,

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -27,6 +27,7 @@ pub const PASCAL_PSI_FACTOR: f64 = 6894.76;
 /// let mbar = earth.as_millibars();
 /// println!("Atmospheric pressure is {} mbar.", mbar);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Pressure {
     pascals: f64,

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -15,6 +15,7 @@ use super::measurement::*;
 /// let mo = r.as_megaohms();
 /// println!("A 4.7 kΩ resistor has {} Ω or {} MΩ", o, mo);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Resistance {
     ohms: f64,

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -22,6 +22,7 @@ pub const SECONDS_HOURS_FACTOR: f64 = 60.0 * 60.0;
 /// let mph = light.as_miles_per_hour();
 /// println!("The speed of light is {} mph.", mph);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Speed {
     meters_per_second: f64,

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -14,6 +14,7 @@ use super::measurement::*;
 /// let fahrenheit = boiling_water.as_fahrenheit();
 /// println!("Boiling water measures at {} degrees fahrenheit.", fahrenheit);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Temperature {
     degrees_kelvin: f64,
@@ -32,6 +33,7 @@ pub struct Temperature {
 /// let difference: TemperatureDelta = boiling_water - frozen_water;
 /// println!("Boiling water is {} above freezing.", difference);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct TemperatureDelta {
     kelvin_degrees: f64,

--- a/src/torque.rs
+++ b/src/torque.rs
@@ -15,6 +15,7 @@ const NEWTON_METRE_POUND_FOOT_FACTOR: f64 = 0.73756326522588;
 /// let engine_torque = Torque::from_pound_foot(250.0);
 /// println!("In metric, that's {} Nm", engine_torque.as_newton_metres());
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Torque {
     newton_metres: f64,

--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -7,6 +7,7 @@ use super::*;
 /// something (which creates a Torque). This struct is what results
 /// from the multiplication, and you have to then convert
 /// it to whichever you want.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TorqueEnergy {
     newton_metres: f64,
 }

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -15,6 +15,7 @@ use super::measurement::*;
 /// let k_v = volts.as_kilovolts();
 /// println!("A 1.5 V battery has {} mV or {} kV", m_v, k_v);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Voltage {
     volts: f64,

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -14,6 +14,7 @@ use super::measurement::*;
 /// let beers = gallon / pint;
 /// println!("A gallon of beer will pour {} pints!", beers);
 /// ```
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug)]
 pub struct Volume {
     liters: f64,


### PR DESCRIPTION
Add optional support for serde as a feature.
No test cases have been added or modified.

Running cargo with `--features serde` will allow the crate to serialize
and deserialize the built-in structs.