### PR TITLE
Update to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.11.1]
+
 ## Added
 
 - Derive `Default` for all measurement structs
 - Accept `lb` as a synonym for `lbs` for mass.
+- Torr, milliTorr and mmHg as units of pressure
 
 ## [0.11.0]
 
@@ -83,7 +86,8 @@ Adds:
 
 Changed Pressure to be in Pascals. Also add a bunch of tests and doc fixes.
 
-[Unreleased]: https://github.com/rust-embedded-community/rust-measurements/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/rust-embedded-community/rust-measurements/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/rust-embedded-community/rust-measurements/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/rust-embedded-community/rust-measurements/compare/v0.10.4...v0.11.0
 [0.10.4]: https://github.com/rust-embedded-community/rust-measurements/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/rust-embedded-community/rust-measurements/compare/v0.10.2...v0.10.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "measurements"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["James O'Cull <jocull@delmarsd.com>",
           "Jonathan Pallant <github@thejpster.org.uk>",
           "Hannah McLaughlin <h@mcla.ug>",


### PR DESCRIPTION
Preparing to release 0.11.1

Closes #63

## Changes

- Derive `Default` for all measurement structs
- Accept `lb` as a synonym for `lbs` for mass.
- Torr, milliTorr and mmHg as units of pressure
