### PR TITLE
add derive for Copy, Clone, Debug, Default for TorqueEnergy

### DIFF
--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -8,6 +8,7 @@ use super::*;
 /// from the multiplication, and you have to then convert
 /// it to whichever you want.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct TorqueEnergy {
     newton_metres: f64,
 }


### PR DESCRIPTION
Add derive of `Copy`, `Clone`, `Debug`, and `Default` for `TorqueEnergy`, as this might be missing as mentioned in #70.