### PR TITLE
Idea to impl FromStr with a macro (without regex crate)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 on:
   push:
-    branches: [ staging, trying, master ]
+    branches: [staging, trying, master]
   pull_request:
 
 name: Build
 
 env:
-  RUSTFLAGS: '--deny warnings'
+  RUSTFLAGS: "--deny warnings"
   MSRV: 1.76
 
 jobs:
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        FEATURES: ['', 'from_str', 'std', 'serde', 'regex']
-        TARGET: ['x86_64-unknown-linux-gnu']
+        FEATURES: ["", "from_str", "std", "serde"]
+        TARGET: ["x86_64-unknown-linux-gnu"]
 
         include:
           # Test nightly but don't fail
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        FEATURES: ['', 'from_str', 'std', 'serde', 'regex']
+        FEATURES: ["", "from_str", "std", "serde"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,10 @@ edition = "2018"
 
 [features]
 std = []
-from_str = ["regex", "std"]
+from_str = ["std"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false, features = [
   "derive",
 ] }
-regex = { version = "1", optional = true }
 libm = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ edition = "2018"
 
 [features]
 std = []
-from_str = ["std"]
+from_str = ["regex", "std"]
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false, features = [
   "derive",
 ] }
+regex = { version = "1", optional = true }
 libm = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "measurements"
 version = "0.11.1"
-authors = ["James O'Cull <jocull@delmarsd.com>",
-          "Jonathan Pallant <github@thejpster.org.uk>",
-          "Hannah McLaughlin <h@mcla.ug>",
-          "Danilo Bargen <mail@dbrgn.ch>",
-          "Tim Alberdingk Thijm <tthijm@cs.princeton.edu>",
-          ]
+authors = [
+  "James O'Cull <jocull@delmarsd.com>",
+  "Jonathan Pallant <github@thejpster.org.uk>",
+  "Hannah McLaughlin <h@mcla.ug>",
+  "Danilo Bargen <mail@dbrgn.ch>",
+  "Tim Alberdingk Thijm <tthijm@cs.princeton.edu>",
+]
 documentation = "https://docs.rs/measurements"
 repository = "https://github.com/rust-embedded-community/rust-measurements"
 keywords = ["measurements", "lengths", "weights", "temperatures", "volumes"]
@@ -17,9 +18,10 @@ edition = "2018"
 
 [features]
 std = []
-from_str = ["regex", "std"]
+from_str = ["std"]
 
 [dependencies]
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-regex = { version = "1", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = [
+  "derive",
+] }
 libm = { version = "0.2" }

--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -1,10 +1,9 @@
 //! Types and constants for handling acceleration.
 
 use crate::{length, measurement::*};
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// The `Acceleration` struct can be used to deal with Accelerations in a common way.
 /// Common metric and imperial units are supported.
@@ -81,36 +80,22 @@ impl Measurement for Acceleration {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Acceleration {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new Acceleration from a string
-    /// Plain numbers in string are considered to be meters per second
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Acceleration::from_metres_per_second_per_second(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([ftmps -2 ²]{1,6})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "m/s2" | "m/s²" | "m s-2" => {
-                        Acceleration::from_meters_per_second_per_second(float_val.parse::<f64>()?)
-                    }
-                    "ft/s2" | "ft/s²" | "fps2" | "ft s-2" => {
-                        Acceleration::from_feet_per_second_per_second(float_val.parse::<f64>()?)
-                    }
-                    _ => Acceleration::from_meters_per_second_per_second(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Acceleration::from_meters_per_second_per_second(
-            val.parse::<f64>()?,
-        ))
-    }
+impl_from_str! {
+    Acceleration,
+    Acceleration::from_meters_per_second_per_second,
+    (
+        Acceleration::from_meters_per_second_per_second,
+        "m/s2",
+        "m/s²",
+        "m s-2"
+    ),
+    (
+        Acceleration::from_feet_per_second_per_second,
+        "ft/s2",
+        "ft/s²",
+        "fps2",
+        "ft s-2"
+    ),
 }
 
 implement_measurement! { Acceleration }

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -3,9 +3,7 @@
 use super::measurement::*;
 
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// The 'Angle' struct can be used to deal with angles in a common way.
 ///
@@ -104,30 +102,11 @@ impl Measurement for Angle {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Angle {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new Angle from a string
-    /// Plain numbers in string are considered to be plain degrees
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Angle::from_degrees(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?(deg|\u{00B0}|rad)\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "deg" | "\u{00B0}" => Angle::from_degrees(float_val.parse::<f64>()?),
-                    "rad" => Angle::from_radians(float_val.parse::<f64>()?),
-                    _ => Angle::from_degrees(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Angle::from_degrees(val.parse::<f64>()?))
-    }
+impl_from_str! {
+    Angle,
+    Angle::from_degrees,
+    (Angle::from_degrees, "deg", "\u{00B0}"),
+    (Angle::from_radians, "rad")
 }
 
 implement_measurement! { Angle }
@@ -135,6 +114,9 @@ implement_measurement! { Angle }
 #[cfg(test)]
 mod test {
     use crate::{angle::*, test_utils::assert_almost_eq, PI};
+
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     #[test]
     fn radians() {

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -2,10 +2,9 @@
 
 use super::measurement::*;
 use crate::PI;
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// The 'AngularVelocity' struct can be used to deal with angular velocities in a common way.
 ///
@@ -72,33 +71,12 @@ impl Measurement for AngularVelocity {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for AngularVelocity {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new AngularVelocity from a string
-    /// Plain numbers in string are considered to be radians per second
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(AngularVelocity::from_radians_per_second(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([radspmhz/]{1,5})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "rad/s" => AngularVelocity::from_radians_per_second(float_val.parse::<f64>()?),
-                    "rpm" => AngularVelocity::from_rpm(float_val.parse::<f64>()?),
-                    "hz" => AngularVelocity::from_hertz(float_val.parse::<f64>()?),
-                    _ => AngularVelocity::from_radians_per_second(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(AngularVelocity::from_radians_per_second(
-            val.parse::<f64>()?,
-        ))
-    }
+impl_from_str! {
+    AngularVelocity,
+    AngularVelocity::from_radians_per_second,
+    (AngularVelocity::from_radians_per_second, "rad/s"),
+    (AngularVelocity::from_rpm, "rpm"),
+    (AngularVelocity::from_hertz, "hz"),
 }
 
 implement_measurement! { AngularVelocity }
@@ -107,6 +85,9 @@ implement_measurement! { AngularVelocity }
 mod test {
     use super::*;
     use crate::test_utils::assert_almost_eq;
+
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     #[test]
     fn rpm() {

--- a/src/area.rs
+++ b/src/area.rs
@@ -2,10 +2,9 @@
 
 use super::length;
 use super::measurement::*;
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// Number of acres in a square meter
 const SQUARE_METER_ACRE_FACTOR: f64 = 1.0 / 4046.86;
@@ -306,53 +305,20 @@ impl Measurement for Area {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Area {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new Area from a string
-    /// Plain numbers in string are considered to be square meters
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Area::from_square_meters(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([a-z2\u{00B2}\u{00B5} ]{1,5})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            println!("{caps:?}");
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().trim().to_lowercase().as_str() {
-                    "nm\u{00B2}" | "nm2" => Area::from_square_nanometers(float_val.parse::<f64>()?),
-                    "\u{00B5}m\u{00B2}" | "\u{00B5}m2" | "um\u{00B2}" | "um2" => {
-                        Area::from_square_micrometers(float_val.parse::<f64>()?)
-                    }
-                    "mm\u{00B2}" | "mm2" => {
-                        Area::from_square_millimeters(float_val.parse::<f64>()?)
-                    }
-                    "cm\u{00B2}" | "cm2" => {
-                        Area::from_square_centimeters(float_val.parse::<f64>()?)
-                    }
-                    "dm\u{00B2}" | "dm2" => Area::from_square_decimeters(float_val.parse::<f64>()?),
-                    "m\u{00B2}" | "m2" => Area::from_square_meters(float_val.parse::<f64>()?),
-                    "km\u{00B2}" | "km2" => Area::from_square_kilometers(float_val.parse::<f64>()?),
-                    "ha" | "hm\u{00B2}" | "hm2" => Area::from_hectares(float_val.parse::<f64>()?),
-                    "acre" | "ac" => Area::from_acres(float_val.parse::<f64>()?),
-                    "ft\u{00B2}" | "ft2" | "sq ft" => {
-                        Area::from_square_feet(float_val.parse::<f64>()?)
-                    }
-                    "yd\u{00B2}" | "yd2" | "sq yd" => {
-                        Area::from_square_yards(float_val.parse::<f64>()?)
-                    }
-                    "mi\u{00B2}" | "mi2" | "sq mi" => {
-                        Area::from_square_miles(float_val.parse::<f64>()?)
-                    }
-                    _ => Area::from_square_meters(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Area::from_square_meters(val.parse::<f64>()?))
-    }
+impl_from_str! {
+    Area, Area::from_square_meters,
+    (Area::from_square_nanometers, "nm²", "nm2"),
+    (Area::from_square_micrometers, "\u{00b5}m²", "\u{03bc}m2", "um²", "um2"),
+    (Area::from_square_millimeters, "mm²", "mm2"),
+    (Area::from_square_centimeters, "cm²", "cm2"),
+    (Area::from_square_decimeters, "dm²", "dm2"),
+    (Area::from_square_meters, "m²", "m2"),
+    (Area::from_square_kilometers, "km²", "km2"),
+    (Area::from_hectares, "ha", "hm²", "hm2"),
+    (Area::from_acres, "acre", "ac"),
+    (Area::from_square_feet, "ft²", "ft2", "sq ft"),
+    (Area::from_square_yards, "yd²", "yd2", "sq yd"),
+    (Area::from_square_miles, "mi²", "mi2", "sq mi"),
 }
 
 implement_measurement! { Area }
@@ -360,6 +326,9 @@ implement_measurement! { Area }
 #[cfg(test)]
 mod test {
     use crate::{area::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     #[test]
     fn square_meters() {

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -1,10 +1,9 @@
 //! Types and constants for handling fractions
 
 use super::measurement::*;
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// The 'Fraction' struct can be used to deal with fractions in a common way.
 ///
@@ -216,42 +215,24 @@ impl_math_fractions! {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Fraction {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new fraction from a string.
-    ///
-    /// Plain numbers in string are considered to be decimal values.
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Fraction::from_decimal(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([a-z % ‰ ‱]{1,9})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "%" | "percent" => Fraction::from_percent(float_val.parse::<f64>()?),
-                    "‰" | "permil" => Fraction::from_permil(float_val.parse::<f64>()?),
-                    "‱" | "permyriad" => Fraction::from_permyriad(float_val.parse::<f64>()?),
-                    "pcm" => Fraction::from_pcm(float_val.parse::<f64>()?),
-                    "ppm" => Fraction::from_ppm(float_val.parse::<f64>()?),
-                    "ppb" => Fraction::from_ppb(float_val.parse::<f64>()?),
-                    "ppt" => Fraction::from_ppt(float_val.parse::<f64>()?),
-                    "ppq" => Fraction::from_ppq(float_val.parse::<f64>()?),
-                    _ => Fraction::from_decimal(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Fraction::from_decimal(val.parse::<f64>()?))
-    }
-}
+impl_from_str!(
+    Fraction,
+    Fraction::from_decimal,
+    (Fraction::from_percent, "%", "percent"),
+    (Fraction::from_permil, "‰", "permil"),
+    (Fraction::from_permyriad, "‱", "permyriad"),
+    (Fraction::from_pcm, "pcm"),
+    (Fraction::from_ppm, "ppm"),
+    (Fraction::from_ppb, "ppb"),
+    (Fraction::from_ppt, "ppt"),
+    (Fraction::from_ppq, "ppq"),
+);
 
 #[cfg(test)]
 mod test {
     use crate::{fraction::*, test_utils::assert_almost_eq};
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     #[test]
     fn as_decimal() {

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -215,7 +215,7 @@ impl_math_fractions! {
 }
 
 #[cfg(feature = "from_str")]
-impl_from_str!(
+impl_from_str! {
     Fraction,
     Fraction::from_decimal,
     (Fraction::from_percent, "%", "percent"),
@@ -226,7 +226,7 @@ impl_from_str!(
     (Fraction::from_ppb, "ppb"),
     (Fraction::from_ppt, "ppt"),
     (Fraction::from_ppq, "ppq"),
-);
+}
 
 #[cfg(test)]
 mod test {

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -1,10 +1,9 @@
 //! Types and constants for handling masses.
 
 use super::measurement::*;
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 // Constants, metric
 
@@ -255,39 +254,19 @@ impl Measurement for Mass {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Mass {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new Mass from a string
-    /// Plain numbers in string are considered to be Kilograms
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Mass::from_kilograms(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([a-zμ]{1,3})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "ug" | "μg" => Mass::from_micrograms(float_val.parse::<f64>()?),
-                    "mg" => Mass::from_milligrams(float_val.parse::<f64>()?),
-                    "ct" => Mass::from_carats(float_val.parse::<f64>()?),
-                    "g" => Mass::from_grams(float_val.parse::<f64>()?),
-                    "kg" => Mass::from_kilograms(float_val.parse::<f64>()?),
-                    "t" => Mass::from_metric_tons(float_val.parse::<f64>()?),
-                    "gr" => Mass::from_grains(float_val.parse::<f64>()?),
-                    "dwt" => Mass::from_pennyweights(float_val.parse::<f64>()?),
-                    "oz" => Mass::from_ounces(float_val.parse::<f64>()?),
-                    "st" => Mass::from_stones(float_val.parse::<f64>()?),
-                    "lb" | "lbs" => Mass::from_pounds(float_val.parse::<f64>()?),
-                    _ => Mass::from_grams(float_val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Mass::from_kilograms(val.parse::<f64>()?))
-    }
+impl_from_str! {
+    Mass, Mass::from_kilograms,
+    (Mass::from_micrograms, "ug", "\u{00B5}g", "\u{03BC}g"),
+    (Mass::from_milligrams, "mg"),
+    (Mass::from_carats, "ct"),
+    (Mass::from_grams, "g"),
+    (Mass::from_kilograms, "kg"),
+    (Mass::from_metric_tons, "t"),
+    (Mass::from_grains, "gr"),
+    (Mass::from_pennyweights, "dwt"),
+    (Mass::from_ounces, "oz"),
+    (Mass::from_stones, "st"),
+    (Mass::from_pounds, "lb", "lbs")
 }
 
 implement_measurement! { Mass }
@@ -295,6 +274,9 @@ implement_measurement! { Mass }
 #[cfg(test)]
 mod test {
     use crate::{mass::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     // Mass Units
     // Metric
@@ -534,10 +516,10 @@ mod test {
     #[test]
     #[cfg(feature = "from_str")]
     fn micrograms_from_string() {
-        assert_almost_eq(123.0, Mass::from_str(" 123ug ").unwrap().as_micrograms());
-        assert_almost_eq(123.0, Mass::from_str("123 ug ").unwrap().as_micrograms());
-        assert_almost_eq(123.0, Mass::from_str("  123μg").unwrap().as_micrograms());
-        assert_almost_eq(123.0, Mass::from_str("123 μg").unwrap().as_micrograms());
+        // assert_almost_eq(123.0, Mass::from_str(" 123ug ").unwrap().as_micrograms());
+        // assert_almost_eq(123.0, Mass::from_str("123 ug ").unwrap().as_micrograms());
+        // assert_almost_eq(123.0, Mass::from_str("  123μg").unwrap().as_micrograms());
+        // assert_almost_eq(123.0, Mass::from_str("123 μg").unwrap().as_micrograms());
     }
 
     #[test]

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -516,10 +516,10 @@ mod test {
     #[test]
     #[cfg(feature = "from_str")]
     fn micrograms_from_string() {
-        // assert_almost_eq(123.0, Mass::from_str(" 123ug ").unwrap().as_micrograms());
-        // assert_almost_eq(123.0, Mass::from_str("123 ug ").unwrap().as_micrograms());
-        // assert_almost_eq(123.0, Mass::from_str("  123μg").unwrap().as_micrograms());
-        // assert_almost_eq(123.0, Mass::from_str("123 μg").unwrap().as_micrograms());
+        assert_almost_eq(123.0, Mass::from_str(" 123ug ").unwrap().as_micrograms());
+        assert_almost_eq(123.0, Mass::from_str("123 ug ").unwrap().as_micrograms());
+        assert_almost_eq(123.0, Mass::from_str("  123μg").unwrap().as_micrograms());
+        assert_almost_eq(123.0, Mass::from_str("123 μg").unwrap().as_micrograms());
     }
 
     #[test]

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -167,3 +167,41 @@ macro_rules! implement_measurement {
         }
     )*)
 }
+
+/// This macro allows implementing `FromStr` for a given measurement without having to write manual
+/// matchers.
+#[macro_export]
+#[cfg(feature = "from_str")]
+macro_rules! impl_from_str {
+    ($t:ty, $d:path, $(($f:path, $($s:expr),+)),+ $(,)?) => {
+        impl ::std::str::FromStr for $t {
+            type Err = ::std::num::ParseFloatError;
+
+            fn from_str(val: &str) -> Result<Self, Self::Err> {
+                // No value provided: return 0.0 in base unit.
+                if val.is_empty() {
+                    return Ok($d(0.0));
+                }
+
+                let err = match val.trim().parse::<f64>() {
+                    Ok(flt) => return Ok($d(flt)),  // assume base unit
+                    Err(e) => e,
+                };
+
+                // Loop trough all tuples (from_xxx path, "&str 1").
+                $(
+                    // Loop through all unit strings.
+                    $(
+                        if let Some(numb) = val.strip_suffix($s) {
+                            if let Ok(flt) = numb.trim().parse::<f64>() {
+                                return Ok($f(flt));
+                            }
+                        }
+                    )+
+                )+
+
+                Err(err)
+            }
+        }
+    };
+}

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -192,7 +192,7 @@ macro_rules! impl_from_str {
                 $(
                     // Loop through all unit strings.
                     $(
-                        if let Some(numb) = val.strip_suffix($s) {
+                        if let Some(numb) = val.trim().to_lowercase().strip_suffix($s.to_lowercase().as_str()) {
                             if let Ok(flt) = numb.trim().parse::<f64>() {
                                 return Ok($f(flt));
                             }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,10 +1,9 @@
 //! Types and constants for handling temperature.
 
 use super::measurement::*;
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// The `Temperature` struct can be used to deal with absolute temperatures in
 /// a common way.
@@ -205,32 +204,12 @@ impl ::core::cmp::PartialOrd for Temperature {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Temperature {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new Temperature from a string
-    /// Plain numbers in string are considered to be Celsius
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Temperature::from_celsius(0.0));
-        }
-
-        let re = Regex::new(r"\s*([0-9.]*)\s?(deg|\u{00B0}|)?\s?([fckrFCKR]{1})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(3).unwrap().as_str().to_uppercase().as_str() {
-                    "F" => Temperature::from_fahrenheit(float_val.parse::<f64>()?),
-                    "C" => Temperature::from_celsius(float_val.parse::<f64>()?),
-                    "K" => Temperature::from_kelvin(float_val.parse::<f64>()?),
-                    "R" => Temperature::from_rankine(float_val.parse::<f64>()?),
-                    _ => Temperature::from_celsius(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Temperature::from_celsius(val.parse::<f64>()?))
-    }
+impl_from_str! {
+    Temperature, Temperature::from_celsius,
+    (Temperature::from_celsius, "C", "\u{00B0}C", "deg C", "degC"),
+    (Temperature::from_kelvin, "K"),
+    (Temperature::from_fahrenheit, "F", "\u{00B0}F", "deg F", "degF"),
+    (Temperature::from_rankine, "R", "\u{00B0}R", "deg R", "degR"),
 }
 
 implement_display!(Temperature);
@@ -239,6 +218,9 @@ implement_measurement!(TemperatureDelta);
 #[cfg(test)]
 mod test {
     use crate::{temperature::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     // Temperature Units
     #[test]

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -1,10 +1,9 @@
 //! Types and constants for handling volumes (that is, three-dimensional space, not loudness).
 
 use super::measurement::*;
+
 #[cfg(feature = "from_str")]
-use regex::Regex;
-#[cfg(feature = "from_str")]
-use std::str::FromStr;
+use crate::impl_from_str;
 
 /// The `Volume` struct can be used to deal with volumes in a common way.
 ///
@@ -344,53 +343,28 @@ impl Measurement for Volume {
 }
 
 #[cfg(feature = "from_str")]
-impl FromStr for Volume {
-    type Err = std::num::ParseFloatError;
-
-    /// Create a new Volume from a string
-    /// Plain numbers in string are considered to be Liters. Defaults for units with US
-    /// and UK variants are considered to be in US without specific "imp" prefix.
-    fn from_str(val: &str) -> Result<Self, Self::Err> {
-        if val.is_empty() {
-            return Ok(Volume::from_liters(0.0));
-        }
-
-        let re = Regex::new(r"(?i)\s*([0-9.]*)\s?([a-z .]{1,10}[0-9³]{0,1})\s*$").unwrap();
-        if let Some(caps) = re.captures(val) {
-            let float_val = caps.get(1).unwrap().as_str();
-            return Ok(
-                match caps.get(2).unwrap().as_str().to_lowercase().as_str() {
-                    "cm3" | "cm\u{00b3}" => {
-                        Volume::from_cubic_centimeters(float_val.parse::<f64>()?)
-                    }
-                    "mm3" | "mm\u{00b3}" => {
-                        Volume::from_cubic_millimeters(float_val.parse::<f64>()?)
-                    }
-                    "ft3" | "ft\u{00b3}" => Volume::from_cubic_feet(float_val.parse::<f64>()?),
-                    "yd3" | "yd\u{00b3}" => Volume::from_cubic_yards(float_val.parse::<f64>()?),
-                    "in3" | "in\u{00b3}" => Volume::from_cubic_inches(float_val.parse::<f64>()?),
-                    "gal" | "us gal" => Volume::from_gallons(float_val.parse::<f64>()?),
-                    "imp gal" => Volume::from_gallons_uk(float_val.parse::<f64>()?),
-                    "cup" => Volume::from_cups(float_val.parse::<f64>()?),
-                    "tsp" => Volume::from_teaspoons(float_val.parse::<f64>()?),
-                    "tbsp" | "t." => Volume::from_tablespoons(float_val.parse::<f64>()?),
-                    "ml" => Volume::from_milliliters(float_val.parse::<f64>()?),
-                    "us fl oz" | "fl oz" => Volume::from_fluid_ounces(float_val.parse::<f64>()?),
-                    "imp fl oz" => Volume::from_fluid_ounces_uk(float_val.parse::<f64>()?),
-                    "m3" | "m\u{00b3}" => Volume::from_cubic_meters(float_val.parse::<f64>()?),
-                    "gt" | "gtt" => Volume::from_drops(float_val.parse::<f64>()?),
-                    "dr" => Volume::from_drams(float_val.parse::<f64>()?),
-                    "l" => Volume::from_litres(float_val.parse::<f64>()?),
-                    "qt" => Volume::from_quarts(float_val.parse::<f64>()?),
-                    "us pt" | "us p" | "p" | "pt" => Volume::from_pints(float_val.parse::<f64>()?),
-                    "imp pt" | "imp p" => Volume::from_pints_uk(float_val.parse::<f64>()?),
-                    _ => Volume::from_litres(val.parse::<f64>()?),
-                },
-            );
-        }
-
-        Ok(Volume::from_liters(val.parse::<f64>()?))
-    }
+impl_from_str! {
+    Volume, Volume::from_liters,
+    (Volume::from_cubic_centimeters, "cm³", "cm3"),
+    (Volume::from_cubic_millimeters, "mm³", "mm3"),
+    (Volume::from_cubic_feet, "ft³", "ft3"),
+    (Volume::from_cubic_yards, "yd³", "yd3"),
+    (Volume::from_cubic_inches, "in³", "in3"),
+    (Volume::from_gallons, "gal", "us gal"),
+    (Volume::from_gallons_uk, "imp gal"),
+    (Volume::from_cups, "cup"),
+    (Volume::from_teaspoons, "tsp"),
+    (Volume::from_tablespoons, "tbsp", "t."),
+    (Volume::from_milliliters, "ml"),
+    (Volume::from_fluid_ounces, "us fl oz", "fl oz"),
+    (Volume::from_fluid_ounces_uk, "imp fl oz"),
+    (Volume::from_cubic_meters, "m³", "m3"),
+    (Volume::from_drops, "gt", "gtt"),
+    (Volume::from_drams, "dr"),
+    (Volume::from_liters, "l"),
+    (Volume::from_quarts, "qt"),
+    (Volume::from_pints, "us pt", "us p", "p", "pt"),
+    (Volume::from_pints_uk, "imp pt", "imp p"),
 }
 
 implement_measurement! { Volume }
@@ -398,6 +372,9 @@ implement_measurement! { Volume }
 #[cfg(test)]
 mod test {
     use crate::{test_utils::assert_almost_eq, volume::*};
+
+    #[cfg(feature = "from_str")]
+    use std::str::FromStr;
 
     // Volume Units
     // Metric


### PR DESCRIPTION
Here's an idea as a draft PR for #73, as I this hopefully makes it easy to see the changes.

Instead of using the `regex` crate, I wrote a macro to simplify the `FromStr` impl. I then used this macro to impl `FromStr` for `Fraction`. This should make it fairly simple to impl `FromStr` for any type that impl `Measurement` and I think catches and deals with the cases that are otherwise impled by default, i.e.,

- An empty string is provided -> default to 0.0 in base units.
- No unit is provided -> parsing succeeds, assumes base units.
- If a unit is detected and the parsing succeeds, the appropriate measurement is returned.
- If all fails, we get a `ParseFloatError`.

Note: I'm using this as a learning experience / an early foray into macro programming, so please advice if there are nonsensical parts here (and apologies for my ignorance). 