### PR TITLE
Make `FromStr` matching case sensitive.

### DIFF
--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -76,7 +76,7 @@ impl_from_str! {
     AngularVelocity::from_radians_per_second,
     (AngularVelocity::from_radians_per_second, "rad/s"),
     (AngularVelocity::from_rpm, "rpm"),
-    (AngularVelocity::from_hertz, "hz"),
+    (AngularVelocity::from_hertz, "Hz"),
 }
 
 implement_measurement! { AngularVelocity }

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -553,8 +553,8 @@ mod test {
     #[test]
     #[cfg(feature = "from_str")]
     fn tonnes_from_string() {
-        assert_almost_eq(123.0, Mass::from_str("123T").unwrap().as_tonnes());
-        assert_almost_eq(123.0, Mass::from_str("123 T").unwrap().as_tonnes());
+        assert_almost_eq(123.0, Mass::from_str("123t").unwrap().as_tonnes());
+        assert_almost_eq(123.0, Mass::from_str("123 t").unwrap().as_tonnes());
     }
 
     #[test]

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -192,7 +192,7 @@ macro_rules! impl_from_str {
                 $(
                     // Loop through all unit strings.
                     $(
-                        if let Some(numb) = val.trim().to_lowercase().strip_suffix($s.to_lowercase().as_str()) {
+                        if let Some(numb) = val.trim().strip_suffix($s) {
                             if let Ok(flt) = numb.trim().parse::<f64>() {
                                 return Ok($f(flt));
                             }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -308,7 +308,7 @@ mod test {
     #[test]
     #[cfg(feature = "from_str")]
     fn fahrenheit_lc_str() {
-        let t = Temperature::from_str("100 f");
+        let t = Temperature::from_str("100 F");
         assert!(t.is_ok());
 
         let o = t.unwrap().as_fahrenheit();
@@ -318,7 +318,7 @@ mod test {
     #[test]
     #[cfg(feature = "from_str")]
     fn fahrenheit_degree_str() {
-        let t = Temperature::from_str("100 deg f");
+        let t = Temperature::from_str("100 deg F");
         assert!(t.is_ok());
 
         let o = t.unwrap().as_fahrenheit();

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -350,20 +350,20 @@ impl_from_str! {
     (Volume::from_cubic_feet, "ft³", "ft3"),
     (Volume::from_cubic_yards, "yd³", "yd3"),
     (Volume::from_cubic_inches, "in³", "in3"),
-    (Volume::from_gallons, "gal", "us gal"),
+    (Volume::from_gallons, "gal", "US gal"),
     (Volume::from_gallons_uk, "imp gal"),
     (Volume::from_cups, "cup"),
     (Volume::from_teaspoons, "tsp"),
-    (Volume::from_tablespoons, "tbsp", "t."),
-    (Volume::from_milliliters, "ml"),
-    (Volume::from_fluid_ounces, "us fl oz", "fl oz"),
+    (Volume::from_tablespoons, "tbsp", "tbsp.", "Tbsp", "Tbsp.", "Tb.", "T."),
+    (Volume::from_milliliters, "ml", "mL"),
+    (Volume::from_fluid_ounces, "US fl oz", "fl oz"),
     (Volume::from_fluid_ounces_uk, "imp fl oz"),
     (Volume::from_cubic_meters, "m³", "m3"),
     (Volume::from_drops, "gt", "gtt"),
     (Volume::from_drams, "dr"),
-    (Volume::from_liters, "l"),
+    (Volume::from_liters, "l", "L"),
     (Volume::from_quarts, "qt"),
-    (Volume::from_pints, "us pt", "us p", "p", "pt"),
+    (Volume::from_pints, "US pt", "US p", "p", "pt"),
     (Volume::from_pints_uk, "imp pt", "imp p"),
 }
 
@@ -756,9 +756,25 @@ mod test {
         assert!(v.is_ok());
         assert_almost_eq(10.0, v.unwrap().as_tablespoons());
 
-        let v2 = Volume::from_str("10T.");
+        let v2 = Volume::from_str("10 tbsp.");
         assert!(v2.is_ok());
         assert_almost_eq(10.0, v2.unwrap().as_tablespoons());
+
+        let v3 = Volume::from_str("10 Tbsp");
+        assert!(v3.is_ok());
+        assert_almost_eq(10.0, v3.unwrap().as_tablespoons());
+
+        let v4 = Volume::from_str("10 Tbsp.");
+        assert!(v4.is_ok());
+        assert_almost_eq(10.0, v4.unwrap().as_tablespoons());
+
+        let v5 = Volume::from_str("10 Tb.");
+        assert!(v5.is_ok());
+        assert_almost_eq(10.0, v5.unwrap().as_tablespoons());
+
+        let v6 = Volume::from_str("10T.");
+        assert!(v6.is_ok());
+        assert_almost_eq(10.0, v6.unwrap().as_tablespoons());
     }
 
     #[test]
@@ -767,6 +783,10 @@ mod test {
         let v = Volume::from_str("10ml");
         assert!(v.is_ok());
         assert_almost_eq(10.0, v.unwrap().as_milliliters());
+
+        let v2 = Volume::from_str("10mL");
+        assert!(v2.is_ok());
+        assert_almost_eq(10.0, v2.unwrap().as_milliliters());
     }
 
     #[test]
@@ -827,6 +847,10 @@ mod test {
         let v = Volume::from_str("10L");
         assert!(v.is_ok());
         assert_almost_eq(10.0, v.unwrap().as_liters());
+
+        let v2 = Volume::from_str("10l");
+        assert!(v2.is_ok());
+        assert_almost_eq(10.0, v2.unwrap().as_liters());
     }
 
     #[test]


### PR DESCRIPTION
As discussed in #77, to impl further, `FromStr` must match strings case sensitive in order to differentiate properly between, e.g., milli (m) and mega (M) prefixes.

This PR drops the case sensitive matching from the `impl_from_str` macro. I went through the failing tests discussed in #77 and double check abbreviations with Wikipedia

- Tons: here the test used "T", but the abbreviation is "t". Test was changed.
- Temperature: I have only seen capital F for Fahrenheit and this agrees with Wikipedia. Changed tests.
- Frequency: Hz should be capitalized as in the test, fixed impl.
- Volumes:
  - "US" should be capitalized as in tests, fixed impl
  - Liters: l and L are valid. Implemented both for liters and milliliters.
  - Tablespoons: Multiple units are possible according to Wikipedia. "tbsp.", "Tbsp.", "Tb.", and "T.". I have also seen "tbsp" and "Tbsp" without a period at the end, so all were impled and tests were extended.

This should also allow now to drop the dependence on `std` for the `FromStr` impl (probably suited for a separate PR).

Thanks!