### PR TITLE
Drop "std" requirement from "from_str" feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        FEATURES: ["", "from_str"]
         TARGET: [thumbv6m-none-eabi, thumbv7m-none-eabi]
 
         include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2018"
 
 [features]
 std = []
-from_str = ["std"]
+from_str = []
 
 [dependencies]
 serde = { version = "1.0", optional = true, default-features = false, features = [

--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -106,7 +106,7 @@ mod test {
     use crate::{speed::Speed, test_utils::assert_almost_eq, *};
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     // Metric
     #[test]

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -116,7 +116,7 @@ mod test {
     use crate::{angle::*, test_utils::assert_almost_eq, PI};
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[test]
     fn radians() {

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -87,7 +87,7 @@ mod test {
     use crate::test_utils::assert_almost_eq;
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[test]
     fn rpm() {

--- a/src/area.rs
+++ b/src/area.rs
@@ -328,7 +328,7 @@ mod test {
     use crate::{area::*, test_utils::assert_almost_eq};
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[test]
     fn square_meters() {

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -232,7 +232,7 @@ impl_from_str! {
 mod test {
     use crate::{fraction::*, test_utils::assert_almost_eq};
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     #[test]
     fn as_decimal() {

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -276,7 +276,7 @@ mod test {
     use crate::{mass::*, test_utils::assert_almost_eq};
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     // Mass Units
     // Metric

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -174,8 +174,8 @@ macro_rules! implement_measurement {
 #[cfg(feature = "from_str")]
 macro_rules! impl_from_str {
     ($t:ty, $d:path, $(($f:path, $($s:expr),+)),+ $(,)?) => {
-        impl ::std::str::FromStr for $t {
-            type Err = ::std::num::ParseFloatError;
+        impl ::core::str::FromStr for $t {
+            type Err = ::core::num::ParseFloatError;
 
             fn from_str(val: &str) -> Result<Self, Self::Err> {
                 // No value provided: return 0.0 in base unit.

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -220,7 +220,7 @@ mod test {
     use crate::{temperature::*, test_utils::assert_almost_eq};
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     // Temperature Units
     #[test]

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -374,7 +374,7 @@ mod test {
     use crate::{test_utils::assert_almost_eq, volume::*};
 
     #[cfg(feature = "from_str")]
-    use std::str::FromStr;
+    use core::str::FromStr;
 
     // Volume Units
     // Metric


### PR DESCRIPTION
As discussed in #74 and thanks to #78, we don't need "std" anymore as a requirement to impl `FromStr`. This PR drops requiring "std" when the "from_str" feature is enabled. Testing "from_str" in the "no-std" build was also enabled.