### PR TITLE
Implement `FromStr` for all measurements that currently do not have an impl

### DIFF
--- a/src/area.rs
+++ b/src/area.rs
@@ -308,7 +308,7 @@ impl Measurement for Area {
 impl_from_str! {
     Area, Area::from_square_meters,
     (Area::from_square_nanometers, "nm²", "nm2"),
-    (Area::from_square_micrometers, "\u{00b5}m²", "\u{03bc}m2", "um²", "um2"),
+    (Area::from_square_micrometers, "\u{00b5}m²", "\u{00b5}m2", "\u{03bc}m²", "\u{03bc}m2", "um²", "um2"),
     (Area::from_square_millimeters, "mm²", "mm2"),
     (Area::from_square_centimeters, "cm²", "cm2"),
     (Area::from_square_decimeters, "dm²", "dm2"),
@@ -576,8 +576,38 @@ mod test {
     #[test]
     #[cfg(feature = "from_str")]
     fn square_micrometer_str() {
-        let t = Area::from_str(" 100.0 um2");
-        assert_almost_eq(t.unwrap().as_square_micrometers(), 100.0);
+        assert_almost_eq(
+            Area::from_str("100 um²").unwrap().as_square_micrometers(),
+            100.0,
+        );
+        assert_almost_eq(
+            Area::from_str("100 um2").unwrap().as_square_micrometers(),
+            100.0,
+        );
+        assert_almost_eq(
+            Area::from_str("100 \u{00B5}m²")
+                .unwrap()
+                .as_square_micrometers(),
+            100.0,
+        );
+        assert_almost_eq(
+            Area::from_str("100 \u{00B5}m2")
+                .unwrap()
+                .as_square_micrometers(),
+            100.0,
+        );
+        assert_almost_eq(
+            Area::from_str("100 \u{03BC}m²")
+                .unwrap()
+                .as_square_micrometers(),
+            100.0,
+        );
+        assert_almost_eq(
+            Area::from_str("100 \u{03BC}m2")
+                .unwrap()
+                .as_square_micrometers(),
+            100.0,
+        );
     }
 
     #[test]

--- a/src/current.rs
+++ b/src/current.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// The `Current` struct can be used to deal with electric potential difference
 /// in a common way.
 ///
@@ -98,9 +101,22 @@ impl Measurement for Current {
 
 implement_measurement! { Current }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Current,
+    Current::from_amperes,
+    (Current::from_nanoamperes, "nA"),
+    (Current::from_microamperes, "uA", "\u{00B5}A", "\u{03BC}A"),
+    (Current::from_milliamperes, "mA"),
+    (Current::from_amperes, "A"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{current::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn as_amperes() {
@@ -185,5 +201,55 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn nanoamperes_from_str() {
+        assert_almost_eq(123.0, Current::from_str("123 nA").unwrap().as_nanoamperes());
+        assert_almost_eq(123.0, Current::from_str("123nA").unwrap().as_nanoamperes());
+        assert_almost_eq(
+            123.0,
+            Current::from_str("  123 nA  ").unwrap().as_nanoamperes(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn microamperes_from_str() {
+        assert_almost_eq(
+            123.4,
+            Current::from_str("123.4 uA").unwrap().as_microamperes(),
+        );
+        assert_almost_eq(
+            123.4,
+            Current::from_str("123.4 μA").unwrap().as_microamperes(),
+        );
+        assert_almost_eq(
+            123.4,
+            Current::from_str("123.4 µA").unwrap().as_microamperes(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn milliamperes_from_str() {
+        assert_almost_eq(
+            123.4,
+            Current::from_str("123.4 mA").unwrap().as_milliamperes(),
+        );
+        assert_almost_eq(
+            123.4,
+            Current::from_str("123.4mA").unwrap().as_milliamperes(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn amperes_from_str() {
+        assert_almost_eq(123.4, Current::from_str("123.4 A").unwrap().as_amperes());
+        assert_almost_eq(123.4, Current::from_str("123.4A").unwrap().as_amperes());
+
+        assert_almost_eq(123.4, Current::from_str("123.4").unwrap().as_amperes());
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 // Constants
 const OCTET_BIT_FACTOR: f64 = 0.125;
 
@@ -168,9 +171,28 @@ impl Measurement for Data {
 
 implement_measurement! { Data }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Data,
+    Data::from_octets,
+    (Data::from_bits, "bit"),
+    (Data::from_octets, "o"),
+    (Data::from_kilooctets, "ko"),
+    (Data::from_megaoctets, "Mo"),
+    (Data::from_gigaoctets, "Go"),
+    (Data::from_teraoctets, "To"),
+    (Data::from_kibioctets, "kio", "Ko"),
+    (Data::from_mebioctets, "Mio"),
+    (Data::from_gibioctets, "Gio"),
+    (Data::from_tebioctets, "Tio"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{data::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     // Metric
     #[test]
@@ -335,5 +357,89 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn bits_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 bit").unwrap().as_bits());
+        assert_almost_eq(123.0, Data::from_str("123bit").unwrap().as_bits());
+        assert_almost_eq(123.0, Data::from_str(" 123 bit   ").unwrap().as_bits());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn octets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 o").unwrap().as_octets());
+        assert_almost_eq(123.0, Data::from_str("123o").unwrap().as_octets());
+        assert_almost_eq(123.0, Data::from_str(" 123 o  ").unwrap().as_octets());
+
+        assert_almost_eq(123.0, Data::from_str(" 123  ").unwrap().as_octets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilooctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 ko").unwrap().as_kilooctets());
+        assert_almost_eq(123.0, Data::from_str("123ko").unwrap().as_kilooctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 ko  ").unwrap().as_kilooctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn megaoctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 Mo").unwrap().as_megaoctets());
+        assert_almost_eq(123.0, Data::from_str("123Mo").unwrap().as_megaoctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 Mo  ").unwrap().as_megaoctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn gigaoctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 Go").unwrap().as_gigaoctets());
+        assert_almost_eq(123.0, Data::from_str("123Go").unwrap().as_gigaoctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 Go  ").unwrap().as_gigaoctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn teraoctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 To").unwrap().as_teraoctets());
+        assert_almost_eq(123.0, Data::from_str("123To").unwrap().as_teraoctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 To  ").unwrap().as_teraoctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kibioctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 kio").unwrap().as_kibioctets());
+        assert_almost_eq(123.0, Data::from_str("123kio").unwrap().as_kibioctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 kio  ").unwrap().as_kibioctets());
+
+        assert_almost_eq(123.0, Data::from_str("123 Ko").unwrap().as_kibioctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn mebioctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 Mio").unwrap().as_mebioctets());
+        assert_almost_eq(123.0, Data::from_str("123Mio").unwrap().as_mebioctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 Mio  ").unwrap().as_mebioctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn gibioctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 Gio").unwrap().as_gibioctets());
+        assert_almost_eq(123.0, Data::from_str("123Gio").unwrap().as_gibioctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 Gio  ").unwrap().as_gibioctets());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn tebioctets_from_str() {
+        assert_almost_eq(123.0, Data::from_str("123 Tio").unwrap().as_tebioctets());
+        assert_almost_eq(123.0, Data::from_str("123Tio").unwrap().as_tebioctets());
+        assert_almost_eq(123.0, Data::from_str(" 123 Tio  ").unwrap().as_tebioctets());
     }
 }

--- a/src/density.rs
+++ b/src/density.rs
@@ -3,6 +3,9 @@
 use super::measurement::*;
 use crate::{mass::Mass, volume::Volume};
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 // Constants, metric
 /// Number of pound per cubic foot in 1 kilograms per cubic meter
 pub const LBCF_KGCM_FACTOR: f64 = 0.062427973725314;
@@ -117,11 +120,22 @@ impl Measurement for Density {
 
 implement_measurement! { Density }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Density,
+    Density::from_kilograms_per_cubic_meter,
+    (Density::from_kilograms_per_cubic_meter, "kg/m3", "kg/m³", "kg m-3"),
+    (Density::from_pounds_per_cubic_feet, "lb/ft3", "lbs/ft3", "lb/ft³", "lbs/ft³", "lb ft-3", "lbs ft-3"),
+}
+
 #[cfg(test)]
 mod test {
 
     use super::*;
     use crate::test_utils::assert_almost_eq;
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     // Metric
     #[test]
@@ -227,5 +241,76 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilograms_per_cubic_meter_from_str() {
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 kg/m3")
+                .unwrap()
+                .as_kilograms_per_cubic_meter(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 kg/m³")
+                .unwrap()
+                .as_kilograms_per_cubic_meter(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 kg m-3")
+                .unwrap()
+                .as_kilograms_per_cubic_meter(),
+        );
+
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4")
+                .unwrap()
+                .as_kilograms_per_cubic_meter(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn pounds_per_cubic_foot_from_str() {
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 lb/ft3")
+                .unwrap()
+                .as_pounds_per_cubic_feet(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 lbs/ft3")
+                .unwrap()
+                .as_pounds_per_cubic_feet(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 lb/ft³")
+                .unwrap()
+                .as_pounds_per_cubic_feet(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 lbs/ft³")
+                .unwrap()
+                .as_pounds_per_cubic_feet(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 lb ft-3")
+                .unwrap()
+                .as_pounds_per_cubic_feet(),
+        );
+        assert_almost_eq(
+            123.4,
+            Density::from_str("123.4 lbs ft-3")
+                .unwrap()
+                .as_pounds_per_cubic_feet(),
+        );
     }
 }

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// The `Energy` struct can be used to deal with energies in a common way.
 /// Common metric and imperial units are supported.
 ///
@@ -116,9 +119,24 @@ impl Measurement for Energy {
 
 implement_measurement! { Energy }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Energy,
+    Energy::from_joules,
+    (Energy::from_joules, "J"),
+    (Energy::from_kcalories, "kcal"),
+    (Energy::from_btu, "BTU", "Btu"),
+    (Energy::from_e_v, "eV"),
+    (Energy::from_watt_hours, "Wh"),
+    (Energy::from_kilowatt_hours, "kWh"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{energy::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn as_kcalories() {
@@ -240,5 +258,48 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn joules_from_str() {
+        assert_almost_eq(123.4, Energy::from_str("123.4 J").unwrap().as_joules());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kcal_from_str() {
+        assert_almost_eq(
+            123.4,
+            Energy::from_str("123.4 kcal").unwrap().as_kcalories(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn btu_from_str() {
+        assert_almost_eq(123.4, Energy::from_str("123.4 BTU").unwrap().as_btu());
+        assert_almost_eq(123.4, Energy::from_str("123.4 Btu").unwrap().as_btu());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn e_v_from_str() {
+        assert_almost_eq(123.4, Energy::from_str("123.4 eV").unwrap().as_e_v());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn watthours_from_str() {
+        assert_almost_eq(123.4, Energy::from_str("123.4 Wh").unwrap().as_watt_hours());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilowatthours_from_str() {
+        assert_almost_eq(
+            123.4,
+            Energy::from_str("123.4 kWh").unwrap().as_kilowatt_hours(),
+        );
     }
 }

--- a/src/force.rs
+++ b/src/force.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// Number of POUNDS force in a Newton
 pub const POUNDS_PER_NEWTON: f64 = 0.224809;
 /// Number of POUNDALS in a Newton.  A poundal is the force necessary to
@@ -137,9 +140,25 @@ impl Measurement for Force {
 
 implement_measurement! { Force }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Force,
+    Force::from_newtons,
+    (Force::from_newtons, "N"),
+    (Force::from_micronewtons, "uN", "\u{00B5}N", "\u{03BC}N"),
+    (Force::from_millinewtons, "mN"),
+    (Force::from_pounds, "lbf"),
+    (Force::from_poundals, "pdl"),
+    (Force::from_kiloponds, "kgf"),
+    (Force::from_dynes, "dyn"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{force::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn newtons() {
@@ -280,5 +299,65 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn newton_from_str() {
+        assert_almost_eq(123.4, Force::from_str("123.4 N").unwrap().as_newtons());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn micronewton_from_str() {
+        assert_almost_eq(
+            123.4,
+            Force::from_str("123.4 uN").unwrap().as_micronewtons(),
+        );
+        assert_almost_eq(
+            123.4,
+            Force::from_str("123.4 \u{03BC}N")
+                .unwrap()
+                .as_micronewtons(),
+        );
+        assert_almost_eq(
+            123.4,
+            Force::from_str("123.4 \u{00B5}N")
+                .unwrap()
+                .as_micronewtons(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn millinewton_from_str() {
+        assert_almost_eq(
+            123.4,
+            Force::from_str("123.4 mN").unwrap().as_millinewtons(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn pounds_from_str() {
+        assert_almost_eq(123.4, Force::from_str("123.4 lbf").unwrap().as_pounds());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn poundals_from_str() {
+        assert_almost_eq(123.4, Force::from_str("123.4 pdl").unwrap().as_poundals());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kiloponds_from_str() {
+        assert_almost_eq(123.4, Force::from_str("123.4 kgf").unwrap().as_kiloponds());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn dynes_from_str() {
+        assert_almost_eq(123.4, Force::from_str("123.4 dyn").unwrap().as_dynes());
     }
 }

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -3,6 +3,9 @@
 use super::measurement::*;
 use crate::time;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// Number of nanohertz in a Hz
 pub const HERTZ_NANOHERTZ_FACTOR: f64 = 1e9;
 /// Number of µHz in a Hz
@@ -161,10 +164,26 @@ impl Measurement for Frequency {
 
 implement_measurement! { Frequency }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Frequency,
+    Frequency::from_hertz,
+    (Frequency::from_hertz, "Hz"),
+    (Frequency::from_nanohertz, "nHz"),
+    (Frequency::from_microhertz, "uHz", "\u{00B5}Hz", "\u{03BC}Hz"),
+    (Frequency::from_millihertz, "mHz"),
+    (Frequency::from_kilohertz, "kHz"),
+    (Frequency::from_megahertz, "MHz"),
+    (Frequency::from_terahertz, "THz"),
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::{test_utils::assert_almost_eq, time};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn hertz() {
@@ -313,5 +332,77 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn hertz_from_str() {
+        assert_almost_eq(123.4, Frequency::from_str("123.4 Hz").unwrap().as_hertz());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn nanohertz_from_str() {
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 nHz").unwrap().as_nanohertz(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn microhertz_from_str() {
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 uHz").unwrap().as_microhertz(),
+        );
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 \u{00B5}Hz")
+                .unwrap()
+                .as_microhertz(),
+        );
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 \u{03BC}Hz")
+                .unwrap()
+                .as_microhertz(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn millihertz_from_str() {
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 mHz").unwrap().as_millihertz(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilohertz_from_str() {
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 kHz").unwrap().as_kilohertz(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn megahertz_from_str() {
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 MHz").unwrap().as_megahertz(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn terahertz_from_str() {
+        assert_almost_eq(
+            123.4,
+            Frequency::from_str("123.4 THz").unwrap().as_terahertz(),
+        );
     }
 }

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -3,6 +3,9 @@
 use super::measurement::*;
 use crate::{density::Density, pressure::Pressure, temperature::Temperature};
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// The `Humidity` struct can be used to deal with relative humidity
 /// in air in a common way. Relative humidity is an important metric used
 /// in weather forecasts.
@@ -176,9 +179,19 @@ impl ::core::cmp::PartialOrd for Humidity {
 
 implement_display!(Humidity);
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Humidity,
+    Humidity::from_ratio,
+    (Humidity::from_percent, "%")
+}
+
 #[cfg(test)]
 mod test {
     use crate::{humidity::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     // Humidity Units
     #[test]
@@ -272,5 +285,17 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn humidity_ratio_from_str() {
+        assert_almost_eq(0.123, Humidity::from_str("0.123").unwrap().as_ratio());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn humidity_percent_from_str() {
+        assert_almost_eq(0.123, Humidity::from_str("0.123 %").unwrap().as_percent());
     }
 }

--- a/src/length.rs
+++ b/src/length.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 // Constants, metric
 
 /// Number of nanometers in a meter
@@ -297,9 +300,31 @@ impl Measurement for Length {
 
 implement_measurement! { Length }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Length,
+    Length::from_meters,
+    (Length::from_meters, "m"),
+    (Length::from_nanometers, "nm"),
+    (Length::from_micrometers, "um", "\u{00B5}m", "\u{03BC}m"),
+    (Length::from_millimeters, "mm"),
+    (Length::from_centimeters, "cm"),
+    (Length::from_decimeters, "dm"),
+    (Length::from_hectometers, "hm"),
+    (Length::from_kilometers, "km"),
+    (Length::from_inches, "in", "\""),
+    (Length::from_feet, "ft"),
+    (Length::from_yards, "yd"),
+    (Length::from_furlongs, "fur"),
+    (Length::from_miles, "mi", "mi."),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{length::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     // Metric
     #[test]
@@ -507,5 +532,109 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn meters_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 m").unwrap().as_meters());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn nanometers_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 nm").unwrap().as_nanometers());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn micrometers_from_str() {
+        assert_almost_eq(
+            123.4,
+            Length::from_str("123.4 um").unwrap().as_micrometers(),
+        );
+        assert_almost_eq(
+            123.4,
+            Length::from_str("123.4 \u{03BC}m")
+                .unwrap()
+                .as_micrometers(),
+        );
+        assert_almost_eq(
+            123.4,
+            Length::from_str("123.4 \u{03BC}m")
+                .unwrap()
+                .as_micrometers(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn millimeters_from_str() {
+        assert_almost_eq(
+            123.4,
+            Length::from_str("123.4 mm").unwrap().as_millimeters(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn centimeters_from_str() {
+        assert_almost_eq(
+            123.4,
+            Length::from_str("123.4 cm").unwrap().as_centimeters(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn decimeters_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 dm").unwrap().as_decimeters());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn hectometers_from_str() {
+        assert_almost_eq(
+            123.4,
+            Length::from_str("123.4 hm").unwrap().as_hectometers(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilometers_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 km").unwrap().as_kilometers());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn inches_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 in").unwrap().as_inches());
+        assert_almost_eq(123.4, Length::from_str("123.4 \"").unwrap().as_inches());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn feet_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 ft").unwrap().as_feet());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn yards_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 yd").unwrap().as_yards());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn furlongs_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 fur").unwrap().as_furlongs());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn miles_from_str() {
+        assert_almost_eq(123.4, Length::from_str("123.4 mi").unwrap().as_miles());
+        assert_almost_eq(123.4, Length::from_str("123.4 mi.").unwrap().as_miles());
     }
 }

--- a/src/power.rs
+++ b/src/power.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// Number of horsepower in a watt
 pub const WATT_HORSEPOWER_FACTOR: f64 = 1.0 / 745.6998715822702;
 /// Number of BTU/min in a watt
@@ -150,9 +153,25 @@ impl Measurement for Power {
 
 implement_measurement! { Power }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Power,
+    Power::from_watts,
+    (Power::from_watts, "W"),
+    (Power::from_microwatts, "uW", "\u{00B5}W", "\u{03BC}W"),
+    (Power::from_milliwatts, "mW"),
+    (Power::from_horsepower, "hp"),
+    (Power::from_ps, "PS", "KM", "cv", "hk", "pk", "k", "ks", "ch"),
+    (Power::from_btu_per_minute, "Btu/min", "BTU/min", "Btu min-1", "BTU min-1"),
+    (Power::from_kilowatts, "kW"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{current::*, power::*, test_utils::assert_almost_eq, voltage::*};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn as_btu_per_minute() {
@@ -298,5 +317,85 @@ mod test {
         let p = Power::from_kilowatts(2.3);
         let u = p / i;
         assert_eq!(u.as_volts(), 230.0);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn watts_from_str() {
+        assert_almost_eq(123.4, Power::from_str("123.4 W").unwrap().as_watts());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn microwatts_from_str() {
+        assert_almost_eq(123.4, Power::from_str("123.4 uW").unwrap().as_microwatts());
+        assert_almost_eq(
+            123.4,
+            Power::from_str("123.4 \u{00B5}W").unwrap().as_microwatts(),
+        );
+        assert_almost_eq(
+            123.4,
+            Power::from_str("123.4 \u{03BC}W").unwrap().as_microwatts(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn milliwatts_from_str() {
+        assert_almost_eq(123.4, Power::from_str("123.4 mW").unwrap().as_milliwatts());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilowatts_from_str() {
+        assert_almost_eq(123.4, Power::from_str("123.4 kW").unwrap().as_kilowatts());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn horsepowerfrom_str() {
+        assert_almost_eq(123.4, Power::from_str("123.4 hp").unwrap().as_horsepower());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn ps_from_str() {
+        assert_almost_eq(123.4, Power::from_str("123.4 PS").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 KM").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 cv").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 hk").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 pk").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 k").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 ks").unwrap().as_ps());
+        assert_almost_eq(123.4, Power::from_str("123.4 ch").unwrap().as_ps());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn btu_per_minute_from_str() {
+        assert_almost_eq(
+            123.4,
+            Power::from_str("123.4 Btu/min")
+                .unwrap()
+                .as_btu_per_minute(),
+        );
+        assert_almost_eq(
+            123.4,
+            Power::from_str("123.4 BTU/min")
+                .unwrap()
+                .as_btu_per_minute(),
+        );
+        assert_almost_eq(
+            123.4,
+            Power::from_str("123.4 Btu min-1")
+                .unwrap()
+                .as_btu_per_minute(),
+        );
+        assert_almost_eq(
+            123.4,
+            Power::from_str("123.4 BTU min-1")
+                .unwrap()
+                .as_btu_per_minute(),
+        );
     }
 }

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// Number of Pascals in an atmosphere
 pub const PASCAL_ATMOSPHERE_FACTOR: f64 = 101_325.0;
 /// Number of Pascals in a hectopascal
@@ -170,10 +173,28 @@ impl Measurement for Pressure {
 
 implement_measurement! { Pressure }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Pressure,
+    Pressure::from_pascals,
+    (Pressure::from_pascals, "Pa"),
+    (Pressure::from_hectopascals, "hPa"),
+    (Pressure::from_kilopascals, "kPa"),
+    (Pressure::from_psi, "psi", "lbf/in²", "lbf/in2", "lbf in-2"),
+    (Pressure::from_bars, "bar"),
+    (Pressure::from_atmospheres, "atm"),
+    (Pressure::from_torrs, "Torr"),
+    (Pressure::from_millitorrs, "mTorr"),
+    (Pressure::from_millimeter_mercury, "mmHg"),
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::test_utils::assert_almost_eq;
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     fn hectopascals() {
@@ -330,5 +351,82 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn pascals_from_str() {
+        assert_almost_eq(123.4, Pressure::from_str("123.4 Pa").unwrap().as_pascals());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn hectopascals_from_str() {
+        assert_almost_eq(
+            123.4,
+            Pressure::from_str("123.4 hPa").unwrap().as_hectopascals(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilopascals_from_str() {
+        assert_almost_eq(
+            123.4,
+            Pressure::from_str("123.4 kPa").unwrap().as_kilopascals(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn psi_from_str() {
+        assert_almost_eq(123.4, Pressure::from_str("123.4 psi").unwrap().as_psi());
+        assert_almost_eq(123.4, Pressure::from_str("123.4 lbf/in²").unwrap().as_psi());
+        assert_almost_eq(123.4, Pressure::from_str("123.4 lbf/in2").unwrap().as_psi());
+        assert_almost_eq(
+            123.4,
+            Pressure::from_str("123.4 lbf in-2").unwrap().as_psi(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn bars_from_str() {
+        assert_almost_eq(123.4, Pressure::from_str("123.4 bar").unwrap().as_bars());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn atmospheres_from_str() {
+        assert_almost_eq(
+            123.4,
+            Pressure::from_str("123.4 atm").unwrap().as_atmospheres(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn torrs_from_str() {
+        assert_almost_eq(123.4, Pressure::from_str("123.4 Torr").unwrap().as_torrs());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn millitorrs_from_str() {
+        assert_almost_eq(
+            123.4,
+            Pressure::from_str("123.4 mTorr").unwrap().as_millitorrs(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn millimeter_mercury_from_str() {
+        assert_almost_eq(
+            123.4,
+            Pressure::from_str("123.4 mmHg")
+                .unwrap()
+                .as_millimeter_mercury(),
+        );
     }
 }

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// The `Resistance` struct can be used to deal with electrical resistance in a
 /// common way.
 ///
@@ -88,9 +91,21 @@ impl Measurement for Resistance {
 
 implement_measurement! { Resistance }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Resistance,
+    Resistance::from_ohms,
+    (Resistance::from_ohms, "\u{2126}", "\u{03A9}"),
+    (Resistance::from_kiloohms, "k\u{2126}", "k\u{03A9}"),
+    (Resistance::from_megaohms, "M\u{2126}", "M\u{03A9}"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{resistance::*, test_utils::assert_almost_eq};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn as_ohms() {
@@ -166,5 +181,52 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn ohms_from_str() {
+        assert_almost_eq(
+            123.4,
+            Resistance::from_str("123.4 \u{2126}").unwrap().as_ohms(),
+        );
+        assert_almost_eq(
+            123.4,
+            Resistance::from_str("123.4 \u{03A9}").unwrap().as_ohms(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kiloohms_from_str() {
+        assert_almost_eq(
+            123.4,
+            Resistance::from_str("123.4 k\u{2126}")
+                .unwrap()
+                .as_kiloohms(),
+        );
+        assert_almost_eq(
+            123.4,
+            Resistance::from_str("123.4 k\u{03A9}")
+                .unwrap()
+                .as_kiloohms(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn megaohms_from_str() {
+        assert_almost_eq(
+            123.4,
+            Resistance::from_str("123.4 M\u{2126}")
+                .unwrap()
+                .as_megaohms(),
+        );
+        assert_almost_eq(
+            123.4,
+            Resistance::from_str("123.4 M\u{03A9}")
+                .unwrap()
+                .as_megaohms(),
+        );
     }
 }

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -3,6 +3,9 @@
 use super::measurement::*;
 use super::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// Number of seconds in a minute
 pub const SECONDS_MINUTES_FACTOR: f64 = 60.0;
 /// Number of minutes in a hour
@@ -112,9 +115,21 @@ impl Measurement for Speed {
 
 implement_measurement! { Speed }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Speed,
+    Speed::from_meters_per_second,
+    (Speed::from_meters_per_second, "m/s", "m s-1"),
+    (Speed::from_kilometers_per_hour, "km/h", "km h-1"),
+    (Speed::from_miles_per_hour, "mph"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{length::Length, speed::*, test_utils::assert_almost_eq, time::Duration};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     // Metric
     #[test]
@@ -232,5 +247,46 @@ mod test {
         assert_eq!(a <= b, true);
         assert_eq!(a > b, false);
         assert_eq!(a >= b, false);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn meters_per_second_from_str() {
+        assert_almost_eq(
+            123.4,
+            Speed::from_str("123.4 m/s").unwrap().as_meters_per_second(),
+        );
+        assert_almost_eq(
+            123.4,
+            Speed::from_str("123.4 m s-1")
+                .unwrap()
+                .as_meters_per_second(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilometers_per_hour_from_str() {
+        assert_almost_eq(
+            123.4,
+            Speed::from_str("123.4 km/h")
+                .unwrap()
+                .as_kilometers_per_hour(),
+        );
+        assert_almost_eq(
+            123.4,
+            Speed::from_str("123.4 km h-1")
+                .unwrap()
+                .as_kilometers_per_hour(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn miles_per_hour_from_str() {
+        assert_almost_eq(
+            123.4,
+            Speed::from_str("123.4 mph").unwrap().as_miles_per_hour(),
+        );
     }
 }

--- a/src/torque.rs
+++ b/src/torque.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// Number of pound-foot in a newton-metre
 const NEWTON_METRE_POUND_FOOT_FACTOR: f64 = 0.73756326522588;
 
@@ -69,10 +72,21 @@ impl Measurement for Torque {
 
 implement_measurement! { Torque }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Torque,
+    Torque::from_newton_meters,
+    (Torque::from_newton_meters, "Nm"),
+    (Torque::from_pound_foot, "lbf ft", "lbf-ft", "lb ft", "lb-ft")
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::test_utils::assert_almost_eq;
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     fn lbf_ft() {
@@ -82,5 +96,35 @@ mod test {
         let r2 = i2.as_pound_foot();
         assert_almost_eq(r1, 338.954);
         assert_almost_eq(r2, 221.269);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn newton_meters_from_str() {
+        assert_almost_eq(
+            123.4,
+            Torque::from_str("123.4 Nm").unwrap().as_newton_metres(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn pound_foot_from_str() {
+        assert_almost_eq(
+            123.4,
+            Torque::from_str("123.4 lbf ft").unwrap().as_pound_foot(),
+        );
+        assert_almost_eq(
+            123.4,
+            Torque::from_str("123.4 lbf-ft").unwrap().as_pound_foot(),
+        );
+        assert_almost_eq(
+            123.4,
+            Torque::from_str("123.4 lb ft").unwrap().as_pound_foot(),
+        );
+        assert_almost_eq(
+            123.4,
+            Torque::from_str("123.4 lb-ft").unwrap().as_pound_foot(),
+        );
     }
 }

--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -2,6 +2,9 @@
 
 use super::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// If you multiply a Force by a Length, we can't tell if you're
 /// pushing something along (which requires Energy) or rotating
 /// something (which creates a Torque). This struct is what results
@@ -38,5 +41,31 @@ impl Measurement for TorqueEnergy {
         TorqueEnergy {
             newton_metres: units,
         }
+    }
+}
+
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    TorqueEnergy,
+    TorqueEnergy::from_base_units,
+    (TorqueEnergy::from_base_units, "Nm", "J"),
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "from_str")]
+    use {super::*, crate::test_utils::assert_almost_eq, core::str::FromStr};
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn torque_energy_from_str() {
+        assert_almost_eq(
+            123.4,
+            TorqueEnergy::from_str("123.4 Nm").unwrap().as_base_units(),
+        );
+        assert_almost_eq(
+            123.4,
+            TorqueEnergy::from_str("123.4 J").unwrap().as_base_units(),
+        );
     }
 }

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -2,6 +2,9 @@
 
 use super::measurement::*;
 
+#[cfg(feature = "from_str")]
+use crate::impl_from_str;
+
 /// The `Voltage` struct can be used to deal with electric potential difference
 /// in a common way.
 ///
@@ -98,9 +101,22 @@ impl Measurement for Voltage {
 
 implement_measurement! { Voltage }
 
+#[cfg(feature = "from_str")]
+impl_from_str! {
+    Voltage,
+    Voltage::from_volts,
+    (Voltage::from_volts, "V"),
+    (Voltage::from_microvolts, "uV", "\u{00B5}V", "\u{03BC}V"),
+    (Voltage::from_millivolts, "mV"),
+    (Voltage::from_kilovolts, "kV"),
+}
+
 #[cfg(test)]
 mod test {
     use crate::{current::*, resistance::*, test_utils::assert_almost_eq, voltage::*};
+
+    #[cfg(feature = "from_str")]
+    use core::str::FromStr;
 
     #[test]
     pub fn as_kilovolts() {
@@ -209,5 +225,47 @@ mod test {
         let u = Voltage::from_kilovolts(4.7);
         let r = u / i;
         assert_eq!(r.as_ohms(), 470.0);
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn volts_from_str() {
+        assert_almost_eq(123.4, Voltage::from_str("123.4 V").unwrap().as_volts());
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn microvolts_from_str() {
+        assert_almost_eq(
+            123.4,
+            Voltage::from_str("123.4 uV").unwrap().as_microvolts(),
+        );
+        assert_almost_eq(
+            123.4,
+            Voltage::from_str("123.4 \u{00B5}V")
+                .unwrap()
+                .as_microvolts(),
+        );
+        assert_almost_eq(
+            123.4,
+            Voltage::from_str("123.4 \u{03BC}V")
+                .unwrap()
+                .as_microvolts(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn millivolts_from_str() {
+        assert_almost_eq(
+            123.4,
+            Voltage::from_str("123.4 mV").unwrap().as_millivolts(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "from_str")]
+    fn kilovolts_from_str() {
+        assert_almost_eq(123.4, Voltage::from_str("123.4 kV").unwrap().as_kilovolts());
     }
 }


### PR DESCRIPTION
Here's the big PR now that all was preparing for :)

This PR implements `FromStr` behind the "from_str" feature for all measurements that currently do not have an implementation. I double checked most abbreviations with Wikipedia. For micron / lower case mu and capital Omega / Ohm sign, I impled both ASCII codes: the greek letter as well as the micron/Resistance Ohm sign for completeness. I also went through the already impled ones and extended where necessary to contain both symbols.

All new `FromStr` impls with units should be tested as well.

For imperial units: I used Wikipedia as a guide and allow for alternative versions (e.g., "Btu" and "BTU") when I feel like I've seen these versions before. 

Closes #77

Thanks!