### PR TITLE
Remove unused imports which error

### DIFF
--- a/src/acceleration.rs
+++ b/src/acceleration.rs
@@ -2,9 +2,6 @@
 
 use crate::{length, measurement::*};
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Acceleration` struct can be used to deal with Accelerations in a common way.
 /// Common metric and imperial units are supported.
 ///

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The 'Angle' struct can be used to deal with angles in a common way.
 ///
 /// # Example

--- a/src/angular_velocity.rs
+++ b/src/angular_velocity.rs
@@ -3,9 +3,6 @@
 use super::measurement::*;
 use crate::PI;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The 'AngularVelocity' struct can be used to deal with angular velocities in a common way.
 ///
 /// # Example

--- a/src/area.rs
+++ b/src/area.rs
@@ -3,9 +3,6 @@
 use super::length;
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of acres in a square meter
 const SQUARE_METER_ACRE_FACTOR: f64 = 1.0 / 4046.86;
 

--- a/src/current.rs
+++ b/src/current.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Current` struct can be used to deal with electric potential difference
 /// in a common way.
 ///

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 // Constants
 const OCTET_BIT_FACTOR: f64 = 0.125;
 

--- a/src/density.rs
+++ b/src/density.rs
@@ -3,9 +3,6 @@
 use super::measurement::*;
 use crate::{mass::Mass, volume::Volume};
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 // Constants, metric
 /// Number of pound per cubic foot in 1 kilograms per cubic meter
 pub const LBCF_KGCM_FACTOR: f64 = 0.062427973725314;

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Energy` struct can be used to deal with energies in a common way.
 /// Common metric and imperial units are supported.
 ///

--- a/src/force.rs
+++ b/src/force.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of POUNDS force in a Newton
 pub const POUNDS_PER_NEWTON: f64 = 0.224809;
 /// Number of POUNDALS in a Newton.  A poundal is the force necessary to

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The 'Fraction' struct can be used to deal with fractions in a common way.
 ///
 /// In comparison to other measurements, fractions can be taken of all other available measurements.

--- a/src/frequency.rs
+++ b/src/frequency.rs
@@ -3,9 +3,6 @@
 use super::measurement::*;
 use crate::time;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of nanohertz in a Hz
 pub const HERTZ_NANOHERTZ_FACTOR: f64 = 1e9;
 /// Number of µHz in a Hz

--- a/src/humidity.rs
+++ b/src/humidity.rs
@@ -3,9 +3,6 @@
 use super::measurement::*;
 use crate::{density::Density, pressure::Pressure, temperature::Temperature};
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Humidity` struct can be used to deal with relative humidity
 /// in air in a common way. Relative humidity is an important metric used
 /// in weather forecasts.

--- a/src/length.rs
+++ b/src/length.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 // Constants, metric
 
 /// Number of nanometers in a meter

--- a/src/mass.rs
+++ b/src/mass.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 // Constants, metric
 
 /// Number of ng in a kg

--- a/src/power.rs
+++ b/src/power.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of horsepower in a watt
 pub const WATT_HORSEPOWER_FACTOR: f64 = 1.0 / 745.6998715822702;
 /// Number of BTU/min in a watt

--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of Pascals in an atmosphere
 pub const PASCAL_ATMOSPHERE_FACTOR: f64 = 101_325.0;
 /// Number of Pascals in a hectopascal

--- a/src/resistance.rs
+++ b/src/resistance.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Resistance` struct can be used to deal with electrical resistance in a
 /// common way.
 ///

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -1,6 +1,5 @@
 //! Types and constants for handling speed.
 
-use super::measurement::*;
 use super::*;
 
 #[cfg(feature = "from_str")]

--- a/src/speed.rs
+++ b/src/speed.rs
@@ -2,9 +2,6 @@
 
 use super::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of seconds in a minute
 pub const SECONDS_MINUTES_FACTOR: f64 = 60.0;
 /// Number of minutes in a hour

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Temperature` struct can be used to deal with absolute temperatures in
 /// a common way.
 ///

--- a/src/torque.rs
+++ b/src/torque.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// Number of pound-foot in a newton-metre
 const NEWTON_METRE_POUND_FOOT_FACTOR: f64 = 0.73756326522588;
 

--- a/src/torque_energy.rs
+++ b/src/torque_energy.rs
@@ -2,9 +2,6 @@
 
 use super::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// If you multiply a Force by a Length, we can't tell if you're
 /// pushing something along (which requires Energy) or rotating
 /// something (which creates a Torque). This struct is what results

--- a/src/voltage.rs
+++ b/src/voltage.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Voltage` struct can be used to deal with electric potential difference
 /// in a common way.
 ///

--- a/src/volume.rs
+++ b/src/volume.rs
@@ -2,9 +2,6 @@
 
 use super::measurement::*;
 
-#[cfg(feature = "from_str")]
-use crate::impl_from_str;
-
 /// The `Volume` struct can be used to deal with volumes in a common way.
 ///
 /// #Example


### PR DESCRIPTION
src/lib.rs does `#![deny(warnings, missing_docs)]` which causes errors for the code removed in this PR.