### PR TITLE
Update CI to build agains MSRV, stable, and nightly smoke build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [staging, trying, master]
+    branches: [staging, trying, main]
   pull_request:
 
 name: Build
@@ -10,18 +10,12 @@ env:
   MSRV: 1.76
 
 jobs:
-  build-std:
+  build-std-msrv:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         FEATURES: ["", "from_str", "std", "serde"]
         TARGET: ["x86_64-unknown-linux-gnu"]
-
-        include:
-          # Test nightly but don't fail
-          - rust: nightly
-            experimental: true
-
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -33,24 +27,82 @@ jobs:
       - name: Test std
         run: cargo test --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
 
-  build-no-std:
+  build-no-std-msrv:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         FEATURES: ["", "from_str"]
         TARGET: [thumbv6m-none-eabi, thumbv7m-none-eabi]
-
-        include:
-          # Test nightly but don't fail
-          - rust: nightly
-            experimental: true
-            TARGET: x86_64-unknown-linux-gnu
-
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.MSRV }}
+          target: ${{ matrix.TARGET }}
+      - name: Build std
+        run: cargo build --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
+
+  build-std-stable:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        FEATURES: ["", "from_str", "std", "serde"]
+        TARGET: ["x86_64-unknown-linux-gnu"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix.TARGET }}
+      - name: Build std
+        run: cargo build --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
+      - name: Test std
+        run: cargo test --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
+
+  build-no-std-stable:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        FEATURES: ["", "from_str"]
+        TARGET: [thumbv6m-none-eabi, thumbv7m-none-eabi]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix.TARGET }}
+      - name: Build std
+        run: cargo build --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
+
+  build-std-nightly:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        TARGET: ["x86_64-unknown-linux-gnu"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          target: ${{ matrix.TARGET }}
+      - name: Build std
+        run: cargo build --target=${{ matrix.TARGET }} --all-features
+      - name: Test std
+        run: cargo test --target=${{ matrix.TARGET }} --all-features
+
+  build-no-std-nightly:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        FEATURES: ["from_str"]
+        TARGET: [thumbv7m-none-eabi]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
           target: ${{ matrix.TARGET }}
       - name: Build std
         run: cargo build --target=${{ matrix.TARGET }} --features=${{ matrix.FEATURES }}
@@ -62,7 +114,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.MSRV }}
-          target: ${{ matrix.TARGET }}
           components: rustfmt
       - name: Format
         run: cargo fmt --all -- --check
@@ -77,7 +128,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.MSRV }}
-          target: ${{ matrix.TARGET }}
           components: clippy
       - name: Clippy
         run: cargo clippy --features=${{ matrix.FEATURES }} -- -D warnings


### PR DESCRIPTION
This PR fixes the CI as discussed in #83.
Main changes are 

- Builds against MSRV stay the same.
- Adds build checks against stable toolchain
- Fixes branch name in push checks against `main` branch
- Adds some "smoke" builds against nightly (if they fail, will not fail CI):
  - std build with `all-features` activated
  - no-std build against one target with "from_str" feature activated.
- Fixes matrix references in `fmt` and `clippy` runs where it didn't make sense

Note: 

- Most runs against toolchains stable and nightly fail now, as expected, see #81.

Not sure how we merge these properly. #81 needs this CI to make sure it is necessary, this PR needs #81 to pass... (YOLO merges?)

To show that #81 will pass with this CI run (and that this CI run will pass with #81):
I rebased the branch `cleanup-1` from @hkBst on top of this commit and renamed the branch staging. This allows it to run the CI in my fork. Output can be found at
https://github.com/trappitsch/rust-measurements/actions/runs/29775289631
